### PR TITLE
fix parsing of gpx files produced by garmin fenix watches

### DIFF
--- a/imports/file_gpxplus.py
+++ b/imports/file_gpxplus.py
@@ -71,6 +71,7 @@ class gpxplus():
 				return True
 		except:
 			#Not gpx file
+			logging.debug("Traceback: %s" % traceback.format_exc())
 			return False
 		return False
 
@@ -100,9 +101,9 @@ class gpxplus():
 		return None
 
 	def startTimeFromFile(self, tree):
-		""" Function to return the first time element from a GPX 1.1 file """
+		""" Function to return the first time element from a GPX 1.1 file (skipping not mandatory metadata section) """
 		root = tree.getroot()
-		timeElement = root.xpath(".//g:time[not(parent::g:metadata)]", namespaces={'g': 'http://www.topografix.com/GPX/1/1'})[0]
+		timeElement = root.xpath(".//g:time[not(parent::g:metadata)]", namespaces={'g':'http://www.topografix.com/GPX/1/1'})[0]
 		if timeElement is not None:
 			return timeElement.text
 		return None


### PR DESCRIPTION
the fenix watch writes a wrong time in the metadata section of the gpx.
It is even in the future.
When using this for calculating the duration, you  get the time and
the pace wrong. I just ran 30km in 0.01 Minutes. That seems to be too fast :)

By using the time of the first trkseg as the starting time, everything
works as expected.
