### PR TITLE
Do not log from Environment.__init__

### DIFF
--- a/pytrainer/environment.py
+++ b/pytrainer/environment.py
@@ -32,7 +32,6 @@ class Environment(object):
         
         """
         self.conf_dir = conf_dir if conf_dir is not None else platform.get_default_conf_dir()
-        logging.info("Initializing environment. Conf dir is: '{0}'.".format(self.conf_dir))
         self.conf_file = self.conf_dir + "/conf.xml"
         self.log_file = self.conf_dir + "/log.out"
         self.temp_dir = self.conf_dir + "/tmp"


### PR DESCRIPTION
Environment is created before running log_setup (and needs to be,
log_setup uses values from Environment). Outputting a log message
before logging is setup causes logging.basicConfig to run at default
values, and so the setup done in log_setup is ignored because logging
is already configured. The info message in Environment.__init__ was
introduced in 5a2292d.