### PR TITLE
replace None by 0 in lap['max_hr'] and lap['avg_hr'] before convertin…

### DIFF
--- a/pytrainer/record.py
+++ b/pytrainer/record.py
@@ -226,6 +226,10 @@ class Record:
 		total_duration = 0
 		ponderate_hr = 0;
 		for lap in laps:
+                        if (lap['max_hr'] is None):
+                            lap['max_hr'] = 0
+                        if (lap['avg_hr'] is None):
+                            lap['avg_hr'] = 0
 			if int(lap['max_hr']) > lap_max_hr:
 				lap_max_hr = int(lap['max_hr'])
 			total_duration = total_duration + float(lap['elapsed_time'])


### PR DESCRIPTION
I sometimes experienced problems while importing runs from Garmin Forerunner 305 using garmintools. It seems that the problem was caused by the fields lap['max_hr'] and lap['avg_hr'] being None (I did not measure the heart rate). This patch fixes this problem for me. However I do not know pytrainer well and cannot say if this might break something else or if there is a better fix for this problem. So I ask the main developers to carefully review this.

I guess that this also addresses the problem described in issue #32.