### PR TITLE
Bugfix: Also consider prior usage when calculating equipment usage

### DIFF
--- a/pytrainer/core/equipment.py
+++ b/pytrainer/core/equipment.py
@@ -213,5 +213,4 @@ class EquipmentService(object):
                          "sum(distance)",
                          "record_equipment.equipment_id = {0}".format(equipment.id))
        usage = result[0][0]
-       return 0 if usage == None else usage
-
+       return (0 if usage == None else usage) + equipment.prior_usage

--- a/pytrainer/test/core/test_equipment.py
+++ b/pytrainer/test/core/test_equipment.py
@@ -343,6 +343,14 @@ class EquipmentServiceTest(unittest.TestCase):
         usage = self.equipment_service.get_equipment_usage(equipment)
         self.assertEquals(0, usage)
 
+    def test_get_equipment_prior_usage(self):
+        self.mock_ddbb.select.return_value = [(None,)]
+        equipment = Equipment()
+        equipment.id = 1
+        equipment.prior_usage = 250
+        usage = self.equipment_service.get_equipment_usage(equipment)
+        self.assertEquals(250, usage)
+
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()


### PR DESCRIPTION
Prior usage was ignored when calculating current equipment usage.
