### PR TITLE
Test EquipmentService and SportService against a real database

### DIFF
--- a/pytrainer/core/equipment.py
+++ b/pytrainer/core/equipment.py
@@ -213,5 +213,8 @@ class EquipmentService(object):
                          "sum(distance)",
                          "record_equipment.equipment_id = {0}".format(equipment.id))
        usage = result[0][0]
-       return 0 if usage == None else usage
+       if not usage:
+          return equipment.prior_usage
+       else:
+          return equipment.prior_usage + usage
 

--- a/pytrainer/core/equipment.py
+++ b/pytrainer/core/equipment.py
@@ -213,8 +213,4 @@ class EquipmentService(object):
                          "sum(distance)",
                          "record_equipment.equipment_id = {0}".format(equipment.id))
        usage = result[0][0]
-       if not usage:
-          return equipment.prior_usage
-       else:
-          return equipment.prior_usage + usage
-
+       return (0 if usage == None else usage) + equipment.prior_usage

--- a/pytrainer/lib/ddbb.py
+++ b/pytrainer/lib/ddbb.py
@@ -292,12 +292,12 @@ class DDBB:
         ret_val = self.ddbbObject.freeExec(sql)
         return ret_val[0][0]
         
-    def create_tables(self):
+    def create_tables(self, add_default=True):
         """Initialise the database schema from an empty database."""
         logging.info("Creating database tables")
         for entry in tablesList:
             self.ddbbObject.createTableDefault(entry, tablesList[entry])
-            if entry in tablesDefaultData:
+            if add_default and entry in tablesDefaultData:
                 logging.debug("Adding default data to %s" % entry)
                 for data_dict in tablesDefaultData[entry]:
                     self.insert_dict(entry, data_dict)

--- a/pytrainer/lib/sqliteUtils.py
+++ b/pytrainer/lib/sqliteUtils.py
@@ -33,9 +33,10 @@ class Sql:
         self.db = None
         confdir = configuration.confdir
         self.ddbb = "%s/pytrainer.ddbb" %confdir
+        self.url = "sqlite:///" + self.ddbb
         
     def get_connection_url(self):
-        return "sqlite:///" + self.ddbb
+        return self.url
     
     def connect(self):
         #si devolvemos 1 ha ido todo con exito

--- a/pytrainer/lib/sqliteUtils.py
+++ b/pytrainer/lib/sqliteUtils.py
@@ -31,9 +31,13 @@ except ImportError:
 class Sql:
     def __init__(self,host=None, ddbb = None, user = None, password = None, configuration = None):
         self.db = None
-        confdir = configuration.confdir
-        self.ddbb = "%s/pytrainer.ddbb" %confdir
-        self.url = "sqlite:///" + self.ddbb
+        if ddbb == 'memory':
+            self.ddbb = ':memory:'
+            self.url = 'sqlite://'
+        else:
+            confdir = configuration.confdir
+            self.ddbb = "%s/pytrainer.ddbb" %confdir
+            self.url = "sqlite:///" + self.ddbb
         
     def get_connection_url(self):
         return self.url

--- a/pytrainer/test/core/equipment_test.py
+++ b/pytrainer/test/core/equipment_test.py
@@ -343,6 +343,14 @@ class EquipmentServiceTest(unittest.TestCase):
         usage = self.equipment_service.get_equipment_usage(equipment)
         self.assertEquals(0, usage)
 
+    def test_get_equipment_prior_usage(self):
+        self.mock_ddbb.select.return_value = [(None,)]
+        equipment = Equipment()
+        equipment.id = 1
+        equipment.prior_usage = 250
+        usage = self.equipment_service.get_equipment_usage(equipment)
+        self.assertEquals(250, usage)
+
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/pytrainer/test/core/sport_test.py
+++ b/pytrainer/test/core/sport_test.py
@@ -21,6 +21,7 @@ from pytrainer.core.sport import Sport, SportService, SportServiceException
 import mock
 from pytrainer.lib.sqliteUtils import Sql
 import pytrainer.core
+from pytrainer.lib.ddbb import DDBB
 
 class SportTest(unittest.TestCase):
     
@@ -220,53 +221,38 @@ class SportTest(unittest.TestCase):
 class SportServiceTest(unittest.TestCase):
     
     def setUp(self):
-        self.mock_ddbb = mock.Mock(spec=Sql)
+        profile = mock.Mock()
+        profile.getValue = mock.Mock(return_value='memory')
+        self.mock_ddbb = DDBB(profile)
+        self.mock_ddbb.connect()
+        self.mock_ddbb.create_tables(add_default=False)
         self.sport_service = SportService(self.mock_ddbb)
+
+    def tearDown(self):
+        self.mock_ddbb.disconnect()
         
     def test_store_sport_should_insert_row_when_sport_has_no_id(self):
-        def mock_select(table, columns, where):
-            call_count = self.mock_ddbb.select.call_count
-            if call_count == 2:
-                return [[1]]
-            return []
-        self.mock_ddbb.select = mock.Mock(wraps=mock_select)
         sport = Sport()
         sport.name = u"Test name"
-        self.sport_service.store_sport(sport)
-        self.mock_ddbb.insert.assert_called_with("sports",  "name,weight,met,max_pace,color",
-                                                 [u"Test name", 0.0, None, None, "0000ff"])
+        sport = self.sport_service.store_sport(sport)
+        self.assertEquals(1, sport.id)
+
     
     def test_store_sport_should_update_row_when_sport_has_id(self):
-        def mock_select(table, columns, where):
-            if columns == "id_sports":
-                return [[1]]
-            else:
-                return [(1, u"", 0, 0, 0, "0")]
-        self.mock_ddbb.select = mock.Mock(wraps=mock_select)
         sport = Sport()
-        sport.id = 1
+        sport.name = u"Test name"
+        sport = self.sport_service.store_sport(sport)
         sport.name = u"New name"
         self.sport_service.store_sport(sport)
-        self.mock_ddbb.update.assert_called_with("sports",  "name,weight,met,max_pace,color",
-                                                 [u"New name", 0.0, None, None, "0000ff"], "id_sports=1")
+        sport = self.sport_service.get_sport(1)
+        self.assertEquals(sport.name, u"New name")
         
     def test_store_sport_should_return_stored_sport(self):
-        sport_ids = []
-        def update_sport_ids(*args):
-            sport_ids.append([1])
-        self.mock_ddbb.insert.side_effect = update_sport_ids
-        def mock_select(table, columns, where):
-            if columns == "id_sports":
-                return sport_ids
-            else:
-                return [(2, u"", 0, 0, 0, "0")]
-        self.mock_ddbb.select = mock.Mock(wraps=mock_select)
         sport = Sport()
         stored_sport = self.sport_service.store_sport(sport)
-        self.assertEquals(2, stored_sport.id)
+        self.assertEquals(1, stored_sport.id)
     
     def test_store_sport_should_error_when_sport_has_unknown_id(self):
-        self.mock_ddbb.select.return_value = []
         sport = Sport()
         sport.id = 100
         try:
@@ -277,40 +263,41 @@ class SportServiceTest(unittest.TestCase):
             self.fail()
             
     def test_store_sport_should_error_when_new_sport_has_duplicate_name(self):
-        self.mock_ddbb.select.return_value = [(1, u"Test name", 150, 12.5, 200, "0")]
-        sport = Sport()
-        sport.name = u"Test name"
+        sport1 = Sport()
+        sport1.name = u"Test name"
+        self.sport_service.store_sport(sport1)
+        sport2 = Sport()
+        sport2.name = u"Test name"
         try:
-            self.sport_service.store_sport(sport)
+            self.sport_service.store_sport(sport2)
         except(SportServiceException):
             pass
         else:
             self.fail()
 
     def test_store_sport_should_error_when_existing_sport_has_duplicate_name(self):
-        def mock_select(table, columns, where):
-            if columns == pytrainer.core.sport._ID_COLUMN:
-                return [[2]]
-            else:
-                return [(1, u"Test name", 0, 0.0, "0"), (2, u"New name", 0, 0.0, "0")]
-        self.mock_ddbb.select = mock.Mock(wraps=mock_select)
-        sport = Sport()
-        sport.id = 1
-        sport.name = u"New name"
+        sport1 = Sport()
+        sport1.name = u"Test name"
+        self.sport_service.store_sport(sport1)
+        sport2 = Sport()
+        sport2.name = u"New name"
+        self.sport_service.store_sport(sport2)
+        sport1.name = u"New name"
         try:
-            self.sport_service.store_sport(sport)
+            self.sport_service.store_sport(sport1)
         except(SportServiceException):
             pass
         else:
             self.fail()
     
     def test_get_sport_returns_none_for_nonexistant_sport(self):
-        self.mock_ddbb.select.return_value = []
         sport = self.sport_service.get_sport(1)
         self.assertEquals(None, sport)
         
     def test_get_sport_returns_sport_with_id(self):
-        self.mock_ddbb.select.return_value = [(1, u"", 0, 0, 0, "0")]
+        sport = Sport()
+        sport.name = u"Test name"
+        self.sport_service.store_sport(sport)
         sport = self.sport_service.get_sport(1)
         self.assertEquals(1, sport.id)
         
@@ -323,19 +310,15 @@ class SportServiceTest(unittest.TestCase):
             self.fail()
         
     def test_get_sport_by_name_returns_none_for_nonexistant_sport(self):
-        self.mock_ddbb.select.return_value = []
         sport = self.sport_service.get_sport("no such sport")
         self.assertEquals(None, sport)
         
     def test_get_sport_by_name_returns_sport_with_name(self):
-        def mock_select(table, columns, where):
-            if columns == "id_sport":
-                return [(1)]
-            else:
-                return [(1, u"rugby", 0, 0, 0, "0")]
-        self.mock_ddbb.select = mock.Mock(wraps=mock_select)
-        sport = self.sport_service.get_sport("rugby")
-        self.assertEquals(u"rugby", sport.name)
+        sport1 = Sport()
+        sport1.name = u"rugby"
+        self.sport_service.store_sport(sport1)
+        sport2 = self.sport_service.get_sport("rugby")
+        self.assertEquals(u"rugby", sport2.name)
         
     def test_get_sport_by_name_raises_error_for_none_sport_name(self):
         try:
@@ -346,7 +329,12 @@ class SportServiceTest(unittest.TestCase):
             self.fail()
         
     def test_get_all_sports_should_return_all_sports_in_query_result(self):
-        self.mock_ddbb.select.return_value = [(1, u"Test name", 0, 0, 0, "0"), (2, u"Test name 2", 0, 0, 0, "0")]
+        sport1 = Sport()
+        sport1.name = u"Test name"
+        self.sport_service.store_sport(sport1)
+        sport2 = Sport()
+        sport2.name = u"Test name 2"
+        self.sport_service.store_sport(sport2)
         sports = self.sport_service.get_all_sports()
         self.assertEquals(2, len(sports))
         sport1 = sports[0]
@@ -355,12 +343,12 @@ class SportServiceTest(unittest.TestCase):
         self.assertEquals(2, sport2.id)
     
     def test_get_all_sports_should_return_no_sports_when_query_result_empty(self):
-        self.mock_ddbb.select.return_value = []
         sports = self.sport_service.get_all_sports()
+        for i in sports:
+            print i.name
         self.assertEquals(0, len(sports))
         
     def test_remove_sport_should_error_when_sport_has_no_id(self):
-        self.mock_ddbb.select.return_value = [(1, u"Test name", 150, 12.5, 200, "0")]
         sport = Sport()
         try:
             self.sport_service.remove_sport(sport)
@@ -370,7 +358,6 @@ class SportServiceTest(unittest.TestCase):
             self.fail()
         
     def test_remove_sport_should_error_when_sport_has_unknown_id(self):
-        self.mock_ddbb.select.return_value = []
         sport = Sport()
         sport.id = 100
         try:
@@ -380,20 +367,10 @@ class SportServiceTest(unittest.TestCase):
         else:
             self.fail()
             
-    def test_remove_sport_should_delete_sport_with_specified_id(self):
-        self.mock_ddbb.select.return_value = [[1]]
-        sport = Sport()
-        sport.id = 1
-        self.sport_service.remove_sport(sport)
-        self.mock_ddbb.delete.assert_called_with("sports", "id_sports=1")
-
     def test_remove_sport_should_remove_associated_entries(self):
-        self.mock_ddbb.select.return_value = [[1]]
         sport = Sport()
-        sport.id = 1
-        delete_arguments = []
-        def mock_delete(*args):
-            delete_arguments.append(args) 
-        self.mock_ddbb.delete = mock.Mock(wraps=mock_delete)
+        sport.name = u"Test name"
+        sport = self.sport_service.store_sport(sport)
         self.sport_service.remove_sport(sport)
-        self.assertEquals(("records", "sport=1"), delete_arguments[0])
+        result = self.sport_service.get_sport(1)
+        self.assertEquals(result, None)

--- a/pytrainer/test/core/sport_test.py
+++ b/pytrainer/test/core/sport_test.py
@@ -310,14 +310,14 @@ class SportServiceTest(unittest.TestCase):
             self.fail()
         
     def test_get_sport_by_name_returns_none_for_nonexistant_sport(self):
-        sport = self.sport_service.get_sport("no such sport")
+        sport = self.sport_service.get_sport_by_name("no such sport")
         self.assertEquals(None, sport)
         
     def test_get_sport_by_name_returns_sport_with_name(self):
         sport1 = Sport()
         sport1.name = u"rugby"
         self.sport_service.store_sport(sport1)
-        sport2 = self.sport_service.get_sport("rugby")
+        sport2 = self.sport_service.get_sport_by_name("rugby")
         self.assertEquals(u"rugby", sport2.name)
         
     def test_get_sport_by_name_raises_error_for_none_sport_name(self):


### PR DESCRIPTION
First make it possible to initialize DDBB with an in-memory sqlite database, and then use that support for testing the services. Also fix a couple of typos in the SportService tests (using get_sport instead of get_sport_by_name).
