### PR TITLE
Fix quoting of string values with sqlite

### DIFF
--- a/pytrainer/lib/sqliteUtils.py
+++ b/pytrainer/lib/sqliteUtils.py
@@ -111,11 +111,11 @@ class Sql:
         if value == None:
             return "null"
         elif type(value) in [str, unicode]:
-            return "\"" + value + "\""
+            return "'%s'" % value
         elif type(value) == datetime.datetime:
-            return value.strftime("\"%Y-%m-%d %H:%M:%S%z\"")
+            return value.strftime("'%Y-%m-%d %H:%M:%S%z'")
         elif type(value) == datetime.date:
-            return value.strftime("\"%Y-%m-%d\"")
+            return value.strftime("'%Y-%m-%d'")
         else:
             return str(value)
         logging.debug('<<')


### PR DESCRIPTION
Using double quotes should be a syntax error, but for sqlite they are
accepted. The results can be rather unexpected (a double quoted string can
be interpreted as a column name instead of a string, etc).