### PR TITLE
Note that matplotlib is always using the GTKAgg backend

### DIFF
--- a/pytrainer/gui/drawArea.py
+++ b/pytrainer/gui/drawArea.py
@@ -17,7 +17,7 @@
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 import matplotlib
-matplotlib.use('GTK')
+matplotlib.use('GTKAgg')
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_gtkagg import FigureCanvasGTKAgg as FigureCanvasGTK
 from matplotlib.backends.backend_gtkagg import NavigationToolbar2GTKAgg as NavigationToolbar


### PR DESCRIPTION
In reality as far as I can tell this was the case due to the imports, but
this single line requested the deprecated GTK backend instead.