### PR TITLE
Directly import gettext in uc.py and profile.py

### DIFF
--- a/pytrainer/lib/uc.py
+++ b/pytrainer/lib/uc.py
@@ -15,6 +15,7 @@
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 from pytrainer.lib.singleton import Singleton
+from gettext import gettext as _
 
 def pace2float(pace_str):
     if pace_str.count(':') != 1:

--- a/pytrainer/profile.py
+++ b/pytrainer/profile.py
@@ -20,6 +20,7 @@
 import os, stat
 import logging
 from StringIO import StringIO
+from gettext import gettext as _
 
 from lxml import etree
 from environment import Environment

--- a/pytrainer/test/core/test_activity.py
+++ b/pytrainer/test/core/test_activity.py
@@ -19,10 +19,6 @@ from datetime import datetime
 from mock import Mock
 from dateutil.tz import tzoffset
 
-# Gettext needs to be initialized before UC is imported (via profile)
-import pytrainer.lib.localization
-pytrainer.lib.localization.initialize_gettext("../../locale")
-
 from pytrainer.lib.ddbb import DDBB
 from pytrainer.profile import Profile
 from pytrainer.lib.uc import UC

--- a/pytrainer/test/lib/test_gpx.py
+++ b/pytrainer/test/lib/test_gpx.py
@@ -17,11 +17,6 @@
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-# Need to set this stuff up so that the translation functions work.  Seems like
-# the module that needs translation ought to have some way of setting this up.
-import pytrainer.lib.localization
-pytrainer.lib.localization.initialize_gettext("../../locale")
-
 import unittest
 import os
 from lxml import etree

--- a/pytrainer/test/lib/test_uc.py
+++ b/pytrainer/test/lib/test_uc.py
@@ -18,10 +18,7 @@ import unittest
 from datetime import date
 from mock import Mock
 
-import pytrainer.lib.localization
 from pytrainer.lib.uc import *
-
-pytrainer.lib.localization.initialize_gettext("../../locale")
 
 class UCUtilTest(unittest.TestCase):
 

--- a/pytrainer/test/test_athlete.py
+++ b/pytrainer/test/test_athlete.py
@@ -18,10 +18,6 @@ import unittest
 from datetime import date
 from mock import Mock
 
-# Gettext needs to be initialized before UC is imported (via profile)
-import pytrainer.lib.localization
-pytrainer.lib.localization.initialize_gettext("../../locale")
-
 from pytrainer.lib.ddbb import DDBB
 from pytrainer.profile import Profile
 from pytrainer.athlete import Athlete


### PR DESCRIPTION
This way the test cases don't need to initialize gettext separately, also
clean them up while at it.