### PR TITLE
gpx: work around missing per-lap calorie info. See #38

### DIFF
--- a/pytrainer/lib/gpx.py
+++ b/pytrainer/lib/gpx.py
@@ -233,8 +233,12 @@ class Gpx:
             totalDistance = 0
             totalDuration = 0
             for lap in laps:
-                lapCalories = lap.findtext(calorieTag)                
-                self.calories += int(lapCalories)
+                try:
+                    lapCalories = lap.findtext(calorieTag)
+                    self.calories += int(lapCalories)
+                except NoneType:
+                    # dummy entry if no per-lap calorie info is stored
+                    self.calories += 0
                 lapDistance = lap.findtext(distanceTag)
                 totalDistance += float(lapDistance)
                 lapDuration_tmp = lap.findtext(elapsedTimeTag)


### PR DESCRIPTION
I believe this should address the issue I was having in importing GPX files from movescount. There isn't always a per-lap calorie count. Unfortunately I cannot get the current version to run on my machine and cannot test. I'll see if I can sort that out, but opening the PR to get comments on this proposed fix.

It doesn't seem that this is the same issue as @bubulle originally reported for #38, but it addresses a problem I am encountering.