### PR TITLE
Fixed importing activities without a sport (GPX).

### DIFF
--- a/pytrainer/gui/windowrecord.py
+++ b/pytrainer/gui/windowrecord.py
@@ -173,7 +173,11 @@ class WindowRecord(SimpleBuilderApp):
             #details["rcd_time"] = (((float(hours) * 60) + float(mins)) * 60) + float(secs)
             details["activity_id"] = activity[0]
             details["rcd_time"] = (float(hours), float(mins), float(secs))
-            details["rcd_sport"] = activity[4]
+            if activity[4] is not None:
+                details["rcd_sport"] = activity[4]
+            else:
+                # No sport was provided, preliminary set the current selection from window
+                details["rcd_sport"] = self.rcd_sport.get_active_text()
             details["rcd_gpxfile"] = activity[5]
             details["file_id"] = activity[6]
             self.activity_data.append(details)


### PR DESCRIPTION
I had issues with importing activities from files that do not specify a sport. When these activities are added to the records window (via populateMultiWindow) the rcd_sport field is None. The records window itself shows the default sport and if no different sport is selected the None is never replaced by an actual sport. This causes issues when adding the activity to the DB as None cannot be resolved to a sport id.
This issue also left my DB in a weird state, since the report window is not closed and every click on "OK" adds another broken entry.

My suggested fix sets the current window selection as the sport if the activity itself does not provide one. I also thought about testing, but the gui stuff is really hard to test and I could not find any documentation on how to run the tests in the first place.