### PR TITLE
Port to Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /messages.pot
 build
 *~
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - TZ=Europe/Kaliningrad PYTRAINER_ALCHEMYURL="mysql://pytrainer@localhost/pytrainer"
   - TZ=Europe/Kaliningrad PYTRAINER_ALCHEMYURL="postgresql://pytrainer@localhost/pytrainer"
 before_install:
-  - sudo apt-get install --no-install-recommends python-gi gir1.2-gtk-3.0 python-lxml python-matplotlib python-tornado python-cairo
+  - sudo apt-get install --no-install-recommends python-gi gir1.2-gtk-3.0 python-lxml python-matplotlib python-tornado python-cairo python3-gi python3-cairo python3-gi-cairo
   - mysql -e "CREATE USER 'pytrainer'@'localhost';"
   - mysql -e "CREATE DATABASE pytrainer;"
   - mysql -e "GRANT ALL PRIVILEGES ON pytrainer . * TO 'pytrainer'@'localhost';"
@@ -16,6 +16,7 @@ before_install:
   - createdb -U postgres -O pytrainer pytrainer
 python:
   - "2.7"
+  - "3.4"
 script: "xvfb-run python setup.py test"
 virtualenv:
   system_site_packages: true

--- a/extensions/openstreetmap/openstreetmap.py
+++ b/extensions/openstreetmap/openstreetmap.py
@@ -192,7 +192,7 @@ class openstreetmap:
             wTree.signal_autoconnect( dic )
             mapviewer = MapViewer(self.pytrainer_main.data_path, pytrainer_main=self.pytrainer_main, box=wTree.get_widget("mapBox"))
             json=None
-            if self.options.has_key('privPolygon'):
+            if 'privPolygon' in self.options:
                 json=self.options['privPolygon']
             htmlfile = Osm(data_path=self.pytrainer_main.data_path, waypoint=json, pytrainer_main=self.pytrainer_main).selectArea()
             mapviewer.display_map(htmlfile=htmlfile)

--- a/extensions/stravaupload/stravaupload.py
+++ b/extensions/stravaupload/stravaupload.py
@@ -103,7 +103,7 @@ class StravaUpload:
         status = None
         values = { 'token': token }
         result = self.get_web_data(STATUS_URL % id, values, "Getting status...")
-        if result.has_key('activity_id'):
+        if 'activity_id' in result:
             status = result['activity_id']
         return status
 

--- a/extensions/wordpress/wordpresslib.py
+++ b/extensions/wordpress/wordpresslib.py
@@ -153,7 +153,7 @@ class WordPressClient:
 		catObj = WordPressCategory()
 		catObj.id 			= int(cat['categoryId'])
 		catObj.name 		= cat['categoryName'] 
-		if cat.has_key('isPrimary'):
+		if 'isPrimary' in cat:
 			catObj.isPrimary 	= cat['isPrimary']
 		return catObj
 		

--- a/pytrainer/athlete.py
+++ b/pytrainer/athlete.py
@@ -97,7 +97,7 @@ class Athlete:
             graphdata['restinghr'].addPoints(x=date, y=row['restinghr'])
             graphdata['maxhr'].addPoints(x=date, y=row['maxhr'])
         #Remove empty data
-        for item in graphdata.keys():
+        for item in list(graphdata.keys()):
             if len(graphdata[item]) == 0:
                 logging.debug( "No values for %s. Removing...." % item )
                 del graphdata[item]

--- a/pytrainer/core/activity.py
+++ b/pytrainer/core/activity.py
@@ -473,7 +473,7 @@ tracks (%s)
         self.time_data['speed_lap'].set_color('#336633', '#336633')
         self.time_data['speed_lap'].graphType = "bar"
         for lap in self.laps:
-            time = float(lap['elapsed_time'].decode('utf-8')) # time in sql is a unicode string
+            time = float(lap['elapsed_time']) # time in sql is a unicode string
             dist = lap['distance']/1000 #distance in km
             try:
                 pace = time/(60*dist) #min/km

--- a/pytrainer/core/activity.py
+++ b/pytrainer/core/activity.py
@@ -90,7 +90,7 @@ class ActivityService(object):
 
     def remove_activity_from_cache(self, id):
         sid = str(id)
-        if sid in self.pool.keys():
+        if sid in list(self.pool.keys()):
             logging.debug("Found activity in pool")
             self.pool_queue.remove(sid)
             del self.pool[sid]
@@ -100,7 +100,7 @@ class ActivityService(object):
             logging.warning("Deprecated call to get_activity with None id")
             return Activity()
         sid = str(id)
-        if sid in self.pool.keys():
+        if sid in list(self.pool.keys()):
             logging.debug("Found activity in pool")
             #Have accessed this activity, place at end of queue
             self.pool_queue.remove(sid)
@@ -606,11 +606,11 @@ tracks (%s)
             self._time_data['hr_p'].addPoints(x=track['time_elapsed'], y=hr_p)
             self._time_data['cadence'].addPoints(x=track['time_elapsed'], y=track['cadence'])
         #Remove data with no values
-        for item in self._distance_data.keys():
+        for item in list(self._distance_data.keys()):
             if len(self._distance_data[item]) == 0:
                 logging.debug( "No values for %s. Removing...." % item )
                 del self._distance_data[item]
-        for item in self._time_data.keys():
+        for item in list(self._time_data.keys()):
             if len(self._time_data[item]) == 0:
                 logging.debug( "No values for %s. Removing...." % item )
                 del self._time_data[item]

--- a/pytrainer/daygraph.py
+++ b/pytrainer/daygraph.py
@@ -16,7 +16,7 @@
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-from timegraph import TimeGraph
+from .timegraph import TimeGraph
 
 class DayGraph(TimeGraph):
 	def __init__(self, sports, vbox = None, combovalue = None):

--- a/pytrainer/extension.py
+++ b/pytrainer/extension.py
@@ -19,9 +19,9 @@
 import os, sys
 import logging
 
-from lib.xmlUtils import XMLParser
+from .lib.xmlUtils import XMLParser
 
-from gui.windowextensions import WindowExtensions
+from .gui.windowextensions import WindowExtensions
 
 class Extension:
 	def __init__(self, data_path = None, parent = None):

--- a/pytrainer/gui/SimpleGladeApp.py
+++ b/pytrainer/gui/SimpleGladeApp.py
@@ -50,7 +50,7 @@ class SimpleBuilderApp(dict):
                 self[data_name] = widget
                 return widget
             else:
-                raise AttributeError, data_name
+                raise AttributeError(data_name)
 
     def __setattr__(self, name, value):
         self[name] = value

--- a/pytrainer/gui/dialogselecttrack.py
+++ b/pytrainer/gui/dialogselecttrack.py
@@ -18,7 +18,7 @@
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-from SimpleGladeApp import SimpleBuilderApp
+from .SimpleGladeApp import SimpleBuilderApp
 from gi.repository import Gtk
 from gi.repository import GObject
 import logging

--- a/pytrainer/gui/drawArea.py
+++ b/pytrainer/gui/drawArea.py
@@ -131,7 +131,7 @@ class DrawArea:
             axis.set_title(_title)
 
         logging.debug("Setting x ticks")
-        tickLocations = [x+0.5 for x in xrange(0, numCols)]
+        tickLocations = [x+0.5 for x in range(0, numCols)]
         axis.set_xticks(tickLocations)
         axis.set_xticklabels(xvalues[0])
         logging.debug("Setting x limits")
@@ -206,7 +206,7 @@ class DrawArea:
 
         ybottoms = [0] * numCols
         yheights = [0] * numCols
-        inds = xrange(0, numCols)
+        inds = range(0, numCols)
         xvals = [x+barOffset for x in range(0, numCols)]
         cellText = []
         self.showGraph=False

--- a/pytrainer/gui/drawArea.py
+++ b/pytrainer/gui/drawArea.py
@@ -193,7 +193,7 @@ class DrawArea:
         else: #Error
             return
 
-        keys = yvalues[0].keys() # days of the week
+        keys = list(yvalues[0].keys()) # days of the week
         numRows = len(keys)
         numCols = len(xvalues[0])
         if numRows == 0:
@@ -253,7 +253,7 @@ class DrawArea:
         if len(xvalues) == 2:
             self.showGraph=False
             ax2 = axis.twinx()
-            keys = yvalues[1].keys()
+            keys = list(yvalues[1].keys())
             ybottoms = [0] * numCols
             yheights = [self.NEARLY_ZERO] * numCols
             for key in keys:

--- a/pytrainer/gui/windowextensions.py
+++ b/pytrainer/gui/windowextensions.py
@@ -16,7 +16,7 @@
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-from SimpleGladeApp import SimpleBuilderApp
+from .SimpleGladeApp import SimpleBuilderApp
 from gi.repository import Gtk
 from gi.repository import GObject
 import os

--- a/pytrainer/gui/windowimportdata.py
+++ b/pytrainer/gui/windowimportdata.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from SimpleGladeApp import SimpleBuilderApp
+from .SimpleGladeApp import SimpleBuilderApp
 from gi.repository import Gtk
 from gi.repository import GObject
 import os, glob, sys

--- a/pytrainer/gui/windowimportdata.py
+++ b/pytrainer/gui/windowimportdata.py
@@ -475,7 +475,7 @@ class WindowImportdata(SimpleBuilderApp):
             logging.debug("Importing %d activities" % len(activities))
             result = self.pytrainer_main.record.newMultiRecord(activities)
             for activity in result:
-                if "db_id" in activity.keys() and type(activity["db_id"]) is types.IntType:
+                if "db_id" in activity.keys() and type(activity["db_id"]) is int:
                     #Activity imported correctly
                     duration = "%0.0f:%0.0f:%02.0f" % (float(activity["rcd_time"][0]), float(activity["rcd_time"][1]), float(activity["rcd_time"][2]))
                     self.updateActivity(activity["activity_id"], 

--- a/pytrainer/gui/windowmain.py
+++ b/pytrainer/gui/windowmain.py
@@ -28,9 +28,9 @@ from gi.repository import GdkPixbuf
 
 import dateutil.parser
 
-from SimpleGladeApp import SimpleBuilderApp
-from popupmenu import PopupMenu
-from aboutdialog import About
+from .SimpleGladeApp import SimpleBuilderApp
+from .popupmenu import PopupMenu
+from .aboutdialog import About
 
 import pytrainer.record
 from pytrainer.lib.date import Date, second2time

--- a/pytrainer/gui/windowmain.py
+++ b/pytrainer/gui/windowmain.py
@@ -890,7 +890,7 @@ class Main(SimpleBuilderApp):
 
         length = len(records)
         rec_set = [0,]
-        for r in xrange(max(count-3, 1) if count>1 else count, min(count+3, length-2) if count < length else count):
+        for r in range(max(count-3, 1) if count>1 else count, min(count+3, length-2) if count < length else count):
             rec_set.append(r)
         if length>1 and count!=length:
             rec_set.append(-1)

--- a/pytrainer/gui/windowmain.py
+++ b/pytrainer/gui/windowmain.py
@@ -501,7 +501,8 @@ class Main(SimpleBuilderApp):
                         if type(cr)==Gtk.CellRendererText:
                             cr.set_property('foreground', 'gray')
 
-                def edited_cb(cell, path, new_text, (liststore, activity)):
+                def edited_cb(cell, path, new_text, data):
+                    liststore, activity = data
                     liststore[path][12] = new_text
                     activity.Laps[int(path)].comments = gtk_str(new_text)
                     self.pytrainer_main.ddbb.session.commit()

--- a/pytrainer/gui/windowmain.py
+++ b/pytrainer/gui/windowmain.py
@@ -430,7 +430,7 @@ class Main(SimpleBuilderApp):
             else:
                 buffer.set_text('')
             if len(activity.equipment) > 0:
-                equipment_text = ", ".join(map(lambda(item): item.description, activity.equipment))
+                equipment_text = ", ".join([item.description for item in activity.equipment])
                 self.label_record_equipment.set_text(equipment_text)
             else:
                 self.label_record_equipment.set_markup("<i>None</i>")

--- a/pytrainer/gui/windowmain.py
+++ b/pytrainer/gui/windowmain.py
@@ -675,11 +675,8 @@ class Main(SimpleBuilderApp):
                     data = activity.time_data
                 else:
                     logging.error("x axis is unknown")
-                #Sort data
-                keys = data.keys()
-                keys.sort()
                 #Populate Y axis data
-                for graphdata in keys:
+                for graphdata in sorted(data.keys()):
                     #First Y axis...
                     #Create button
                     y1button = Gtk.CheckButton(label=data[graphdata].title)
@@ -835,9 +832,7 @@ class Main(SimpleBuilderApp):
             GObject.TYPE_STRING,       #time
             )
 
-        ds = DISTANCES.keys()
-        ds = sorted(ds)
-        for d in ds:
+        for d in sorted(DISTANCES.keys()):
             v = DISTANCES[d]
             iter = projected_store.append()
             projected_store.set (

--- a/pytrainer/gui/windowplugins.py
+++ b/pytrainer/gui/windowplugins.py
@@ -16,7 +16,7 @@
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-from SimpleGladeApp import SimpleBuilderApp
+from .SimpleGladeApp import SimpleBuilderApp
 from gi.repository import Gtk
 from gi.repository import GObject
 import os

--- a/pytrainer/gui/windowprofile.py
+++ b/pytrainer/gui/windowprofile.py
@@ -17,8 +17,8 @@
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 from __future__ import division
-from SimpleGladeApp import SimpleBuilderApp
-from windowcalendar import WindowCalendar
+from .SimpleGladeApp import SimpleBuilderApp
+from .windowcalendar import WindowCalendar
 from pytrainer.core.equipment import EquipmentService
 from pytrainer.gui.equipment import EquipmentUi
 from pytrainer.core.sport import Sport

--- a/pytrainer/gui/windowprofile.py
+++ b/pytrainer/gui/windowprofile.py
@@ -88,7 +88,7 @@ class WindowProfile(SimpleBuilderApp):
         # Need to think if it does make sense to use pprint -> compatibility issues
         #print list_options
         for i in self.conf_options.keys():
-            if not list_options.has_key(i):
+            if i not in list_options:
                 logging.info('No list options for %s' %s)
                 continue
             if i == "default_viewer":

--- a/pytrainer/gui/windowrecord.py
+++ b/pytrainer/gui/windowrecord.py
@@ -21,8 +21,8 @@ import os
 import logging
 import traceback
 from gi.repository import Gtk, GObject
-from SimpleGladeApp import SimpleBuilderApp
-from windowcalendar import WindowCalendar
+from .SimpleGladeApp import SimpleBuilderApp
+from .windowcalendar import WindowCalendar
 
 from pytrainer.lib.date import getLocalTZ, time2second
 import dateutil.parser

--- a/pytrainer/gui/windowrecord.py
+++ b/pytrainer/gui/windowrecord.py
@@ -432,7 +432,7 @@ class WindowRecord(SimpleBuilderApp):
             Needed as once sports are deleted there are gaps in the list...
         """
         count = 0
-        for key, value in self.listSport.iteritems():
+        for key, value in self.listSport.items():
             if key == sportID: 
                 return count
             count +=1
@@ -444,7 +444,7 @@ class WindowRecord(SimpleBuilderApp):
             Needed as once sports are deleted there are gaps in the list...
         """
         count = 0
-        for key, value in self.listSport.iteritems():
+        for key, value in self.listSport.items():
             if value == sport: 
                 return count
             count +=1

--- a/pytrainer/heartrategraph.py
+++ b/pytrainer/heartrategraph.py
@@ -16,7 +16,7 @@
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-from gui.drawArea import DrawArea
+from .gui.drawArea import DrawArea
 import logging
 
 class HeartRateGraph:

--- a/pytrainer/importdata.py
+++ b/pytrainer/importdata.py
@@ -16,7 +16,7 @@
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-from gui.windowimportdata import WindowImportdata
+from .gui.windowimportdata import WindowImportdata
 
 class Importdata:
 	def __init__(self, sport_service, data_path = None, parent = None, config = None):

--- a/pytrainer/lib/gpx.py
+++ b/pytrainer/lib/gpx.py
@@ -203,7 +203,7 @@ class Gpx:
                 if num_elements > 0:
                     if num_elements == 1: # old _non compliant_ pytrainer estructure
                         #logging.debug("lap_summary[0]: %s" % etree.tostring(lap_summary[0]))
-                        for key in summary_dict.keys():
+                        for key in list(summary_dict.keys()):
                             summary_dict[key] = lap_summary[0].findtext(mainNS.substitute(tag=key))
                             logging.debug("%s: %s" % (key, summary_dict[key]))
                     else:

--- a/pytrainer/lib/srtmlayer.py
+++ b/pytrainer/lib/srtmlayer.py
@@ -7,7 +7,7 @@ from math import floor, ceil
 from osgeo import gdal, gdalnumeric
 
 from pytrainer.lib.srtmtiff import SrtmTiff
-import srtmdownload
+from . import srtmdownload
 
 class SrtmLayer(object):
     """

--- a/pytrainer/lib/xmlUtils.py
+++ b/pytrainer/lib/xmlUtils.py
@@ -67,7 +67,7 @@ class XMLParser:
 
 	def setValue(self,tagname,variable,value):
 		root = self.xmldoc.getElementsByTagName(tagname)[0]
-		if root.attributes.has_key(variable):
+		if variable in root.attributes:
 			root.attributes[variable]._set_value(value)
 		else:
 			root.setAttribute(variable,value)

--- a/pytrainer/main.py
+++ b/pytrainer/main.py
@@ -28,24 +28,24 @@ import gi
 gi.require_version('Gtk', '3.0')
 
 from pytrainer.lib.date import DateRange
-from upgrade.data import initialize_data
-from environment import Environment
-from record import Record
-from waypoint import WaypointService
-from extension import Extension
-from importdata import Importdata
-from plugins import Plugins
-from profile import Profile
+from .upgrade.data import initialize_data
+from .environment import Environment
+from .record import Record
+from .waypoint import WaypointService
+from .extension import Extension
+from .importdata import Importdata
+from .plugins import Plugins
+from .profile import Profile
 from pytrainer.core.sport import SportService
-from athlete import Athlete
-from stats import Stats
+from .athlete import Athlete
+from .stats import Stats
 
-from gui.windowmain import Main
-from gui.warning import Warning
-from lib.date import Date, getNameMonth
+from .gui.windowmain import Main
+from .gui.warning import Warning
+from .lib.date import Date, getNameMonth
 from pytrainer.core.activity import ActivityService
-from lib.ddbb import DDBB
-from lib.uc import UC
+from .lib.ddbb import DDBB
+from .lib.uc import UC
 
 class pyTrainer:
     def __init__(self,filename = None, data_path = None):
@@ -503,14 +503,14 @@ class pyTrainer:
 
     def exportCsv(self):
         logging.debug('>>')
-        from save import Save
+        from .save import Save
         save = Save(self.data_path, self.record)
         save.run()
         logging.debug('<<')
 
     def editProfile(self):
         logging.debug('>>')
-        from gui.windowprofile import WindowProfile
+        from .gui.windowprofile import WindowProfile
         self.profile.refreshConfiguration()
         if self.profilewindow is None:
             self.profilewindow = WindowProfile(self._sport_service, self.data_path, self.profile, pytrainer_main=self)

--- a/pytrainer/monthgraph.py
+++ b/pytrainer/monthgraph.py
@@ -37,7 +37,7 @@ class MonthGraph(TimeGraph):
         self.KEY_FORMAT = "%d"
         
     def drawgraph(self,values, daysInMonth):
-        TimeGraph.drawgraph(self, values, x_func=lambda x: list([u'%02d' % d for d in xrange(1,daysInMonth+1)]))
+        TimeGraph.drawgraph(self, values, x_func=lambda x: list([u'%02d' % d for d in range(1,daysInMonth+1)]))
 
     def get_values2(self,values,value_selected,daysInMonth):
         #hacemos una relacion entre el value_selected y los values / we make a relation between value_selected and the values

--- a/pytrainer/monthgraph.py
+++ b/pytrainer/monthgraph.py
@@ -18,7 +18,7 @@
 
 import dateutil
 import datetime
-from timegraph import TimeGraph
+from .timegraph import TimeGraph
 
 class MonthGraph(TimeGraph):
 

--- a/pytrainer/plugins.py
+++ b/pytrainer/plugins.py
@@ -20,9 +20,9 @@ import os
 import sys
 import logging
 
-from lib.xmlUtils import XMLParser
+from .lib.xmlUtils import XMLParser
 
-from gui.windowplugins import WindowPlugins
+from .gui.windowplugins import WindowPlugins
 
 class Plugins:
 	def __init__(self, data_path = None, parent = None):

--- a/pytrainer/profile.py
+++ b/pytrainer/profile.py
@@ -23,9 +23,9 @@ from io import BytesIO
 from gettext import gettext as _
 
 from lxml import etree
-from environment import Environment
+from .environment import Environment
 from pytrainer.lib.singleton import Singleton
-from lib.uc import UC
+from .lib.uc import UC
 
 class Profile(Singleton):
     def __init__(self):

--- a/pytrainer/profile.py
+++ b/pytrainer/profile.py
@@ -232,7 +232,7 @@ class Profile(Singleton):
         if tag != "pytraining":
             logging.critical("ERROR - pytraining is the only profile tag supported")
             return None
-        elif not self.configuration.has_key(variable):
+        elif variable not in self.configuration:
             return None
         return self.configuration[variable]
 

--- a/pytrainer/profile.py
+++ b/pytrainer/profile.py
@@ -244,7 +244,7 @@ class Profile(Singleton):
         if self.xml_tree is None:
             #new config file....
             self.xml_tree = etree.parse(BytesIO(b'''<?xml version='1.0' encoding='UTF-8'?><pytraining />'''))
-        self.xml_tree.getroot().set(variable, value.decode('utf-8'))
+        self.xml_tree.getroot().set(variable, value)
         if not delay_write:
             self.saveProfile()
         logging.debug("<<")

--- a/pytrainer/profile.py
+++ b/pytrainer/profile.py
@@ -252,7 +252,7 @@ class Profile(Singleton):
     def setProfile(self,list_options):
         logging.debug(">>")
         for option, value in list_options.items():
-            logging.debug("Adding "+option+"|"+value)
+            logging.debug("Adding %s|%s", option, value)
             self.setValue("pytraining",option,value,delay_write=True)
         self.uc.set_us(list_options['prf_us_system'])
         logging.debug("<<")

--- a/pytrainer/record.py
+++ b/pytrainer/record.py
@@ -22,10 +22,10 @@ import shutil
 import logging
 import datetime
 
-from gui.windowrecord import WindowRecord
-from gui.dialogselecttrack import DialogSelectTrack
-from lib.date import Date, time2second
-from lib.gpx import Gpx
+from .gui.windowrecord import WindowRecord
+from .gui.dialogselecttrack import DialogSelectTrack
+from .lib.date import Date, time2second
+from .lib.gpx import Gpx
 from pytrainer.core.equipment import EquipmentService, Equipment
 from pytrainer.core.sport import Sport
 from pytrainer.core.activity import Activity, Lap
@@ -385,7 +385,7 @@ class Record:
             self._select_trkfromgpx(gpxfile,tracks)
         else:
             msg = _("pytrainer can't import data from your gpx file")
-            from gui.warning import Warning
+            from .gui.warning import Warning
             warning = Warning(self.data_path)
             warning.set_text(msg)
             warning.run()

--- a/pytrainer/recordgraph.py
+++ b/pytrainer/recordgraph.py
@@ -17,7 +17,7 @@
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 import logging
-from gui.drawArea import DrawArea
+from .gui.drawArea import DrawArea
 
 from gi.repository import Gtk
 

--- a/pytrainer/save.py
+++ b/pytrainer/save.py
@@ -16,7 +16,7 @@
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-from lib.fileUtils import fileUtils
+from .lib.fileUtils import fileUtils
 from pytrainer.gui.dialogs import save_file_chooser_dialog
 import logging
 import traceback

--- a/pytrainer/test/core/test_activity.py
+++ b/pytrainer/test/core/test_activity.py
@@ -75,64 +75,64 @@ class ActivityTest(unittest.TestCase):
         self.uc.set_us(False)
 
     def test_activity_date_time(self):
-        self.assertEquals(self.activity.date_time, datetime.datetime(2016, 7, 24,
+        self.assertEqual(self.activity.date_time, datetime.datetime(2016, 7, 24,
                                                                         12, 58, 23,
                                                     tzinfo=tzoffset(None, 10800)))
 
     def test_activity_distance(self):
-        self.assertEquals(self.activity.distance, 46.18)
+        self.assertEqual(self.activity.distance, 46.18)
 
     def test_activity_sport_name(self):
-        self.assertEquals(self.activity.sport_name, 'Mountain Bike')
+        self.assertEqual(self.activity.sport_name, 'Mountain Bike')
 
     def test_activity_duration(self):
-        self.assertEquals(self.activity.duration, 7426)
+        self.assertEqual(self.activity.duration, 7426)
 
     def test_activity_time(self):
-        self.assertEquals(self.activity.time, self.activity.duration)
+        self.assertEqual(self.activity.time, self.activity.duration)
 
     def test_activity_starttime(self):
-        self.assertEquals(self.activity.starttime, '12:58:23 PM')
+        self.assertEqual(self.activity.starttime, '12:58:23 PM')
 
     def test_activity_time_tuple(self):
-        self.assertEquals(self.activity.time_tuple, (2, 3, 46))
+        self.assertEqual(self.activity.time_tuple, (2, 3, 46))
 
     def test_activity_lap(self):
         self.maxDiff = None
-        self.assertEquals(self.activity.laps[0], {'distance': 46181.9, 'end_lon': None, 'lap_number': 0, 'start_lon': None, 'id_lap': 1, 'calories': 1462, 'comments': None, 'laptrigger': u'manual', 'elapsed_time': u'7426.0', 'record': 1, 'intensity': u'active', 'avg_hr': 136, 'max_hr': 173, 'end_lat': None, 'start_lat': None, 'max_speed': None})
+        self.assertEqual(self.activity.laps[0], {'distance': 46181.9, 'end_lon': None, 'lap_number': 0, 'start_lon': None, 'id_lap': 1, 'calories': 1462, 'comments': None, 'laptrigger': u'manual', 'elapsed_time': u'7426.0', 'record': 1, 'intensity': u'active', 'avg_hr': 136, 'max_hr': 173, 'end_lat': None, 'start_lat': None, 'max_speed': None})
         lap = self.activity.Laps[0]
-        self.assertEquals(lap.distance, 46181.9)
-        self.assertEquals(lap.duration, 7426.0)
-        self.assertEquals(lap.calories, 1462)
-        self.assertEquals(lap.avg_hr, 136)
-        self.assertEquals(lap.max_hr, 173)
-        self.assertEquals(lap.activity, self.activity)
-        self.assertEquals(lap.lap_number, 0)
-        self.assertEquals(lap.intensity, u'active')
-        self.assertEquals(lap.laptrigger, u'manual')
+        self.assertEqual(lap.distance, 46181.9)
+        self.assertEqual(lap.duration, 7426.0)
+        self.assertEqual(lap.calories, 1462)
+        self.assertEqual(lap.avg_hr, 136)
+        self.assertEqual(lap.max_hr, 173)
+        self.assertEqual(lap.activity, self.activity)
+        self.assertEqual(lap.lap_number, 0)
+        self.assertEqual(lap.intensity, u'active')
+        self.assertEqual(lap.laptrigger, u'manual')
 
     def test_activity_get_value_f(self):
-        self.assertEquals(self.activity.get_value_f('distance', "%0.2f"), '46.18')
-        self.assertEquals(self.activity.get_value_f('average', "%0.2f"), '22.39')
-        self.assertEquals(self.activity.get_value_f('maxspeed', "%0.2f"), '44.67')
-        self.assertEquals(self.activity.get_value_f('time', '%s'), '2:03:46')
-        self.assertEquals(self.activity.get_value_f('calories', "%0.0f"), '1462')
-        self.assertEquals(self.activity.get_value_f('pace', "%s"), '2:24')
-        self.assertEquals(self.activity.get_value_f('maxpace', "%s"), '1:12')
-        self.assertEquals(self.activity.get_value_f('upositive', "%0.2f"), '553.06')
-        self.assertEquals(self.activity.get_value_f('unegative', "%0.2f"), '564.08')
+        self.assertEqual(self.activity.get_value_f('distance', "%0.2f"), '46.18')
+        self.assertEqual(self.activity.get_value_f('average', "%0.2f"), '22.39')
+        self.assertEqual(self.activity.get_value_f('maxspeed', "%0.2f"), '44.67')
+        self.assertEqual(self.activity.get_value_f('time', '%s'), '2:03:46')
+        self.assertEqual(self.activity.get_value_f('calories', "%0.0f"), '1462')
+        self.assertEqual(self.activity.get_value_f('pace', "%s"), '2:24')
+        self.assertEqual(self.activity.get_value_f('maxpace', "%s"), '1:12')
+        self.assertEqual(self.activity.get_value_f('upositive', "%0.2f"), '553.06')
+        self.assertEqual(self.activity.get_value_f('unegative', "%0.2f"), '564.08')
 
     def test_activity_get_value_f_us(self):
         self.uc.set_us(True)
-        self.assertEquals(self.activity.get_value_f('distance', "%0.2f"), '28.69')
-        self.assertEquals(self.activity.get_value_f('average', "%0.2f"), '13.91')
-        self.assertEquals(self.activity.get_value_f('maxspeed', "%0.2f"), '27.76')
-        self.assertEquals(self.activity.get_value_f('time', '%s'), '2:03:46')
-        self.assertEquals(self.activity.get_value_f('calories', "%0.0f"), '1462')
-        self.assertEquals(self.activity.get_value_f('pace', "%s"), '3:52')
-        self.assertEquals(self.activity.get_value_f('maxpace', "%s"), '1:56')
-        self.assertEquals(self.activity.get_value_f('upositive', "%0.2f"), '1814.50')
-        self.assertEquals(self.activity.get_value_f('unegative', "%0.2f"), '1850.66')
+        self.assertEqual(self.activity.get_value_f('distance', "%0.2f"), '28.69')
+        self.assertEqual(self.activity.get_value_f('average', "%0.2f"), '13.91')
+        self.assertEqual(self.activity.get_value_f('maxspeed', "%0.2f"), '27.76')
+        self.assertEqual(self.activity.get_value_f('time', '%s'), '2:03:46')
+        self.assertEqual(self.activity.get_value_f('calories', "%0.0f"), '1462')
+        self.assertEqual(self.activity.get_value_f('pace', "%s"), '3:52')
+        self.assertEqual(self.activity.get_value_f('maxpace', "%s"), '1:56')
+        self.assertEqual(self.activity.get_value_f('upositive', "%0.2f"), '1814.50')
+        self.assertEqual(self.activity.get_value_f('unegative', "%0.2f"), '1850.66')
 
     def test_activity_service_null(self):
         none_activity = self.service.get_activity(None)
@@ -149,12 +149,12 @@ class ActivityTest(unittest.TestCase):
 
     def test_activities_for_day(self):
         activity = list(self.service.get_activities_for_day(datetime.date(2016, 7, 24)))[0]
-        self.assertEquals(self.activity, activity)
+        self.assertEqual(self.activity, activity)
 
     def test_activities_period(self):
         activity = list(self.service.get_activities_period(DateRange.for_week_containing(datetime.date(2016, 7, 24))))[0]
-        self.assertEquals(self.activity, activity)
+        self.assertEqual(self.activity, activity)
 
     def test_all_activities(self):
         activity = list(self.service.get_all_activities())[0]
-        self.assertEquals(self.activity, activity)
+        self.assertEqual(self.activity, activity)

--- a/pytrainer/test/core/test_equipment.py
+++ b/pytrainer/test/core/test_equipment.py
@@ -42,14 +42,14 @@ class EquipmentTest(unittest.TestCase):
     def test_id_set_to_integer(self):
         equipment = Equipment()
         equipment.id = 2
-        self.assertEquals(2, equipment.id)
+        self.assertEqual(2, equipment.id)
             
     def test_id_set_to_numeric_string(self):
         equipment = Equipment()
         equipment.id = "3"
         self.ddbb.session.add(equipment)
         self.ddbb.session.commit()
-        self.assertEquals(3, equipment.id)
+        self.assertEqual(3, equipment.id)
 
     def test_id_set_to_non_numeric_string(self):
         if self.ddbb.engine.name == 'mysql':
@@ -66,7 +66,7 @@ class EquipmentTest(unittest.TestCase):
             
     def test_description_defaults_to_empty_string(self):
         equipment = Equipment()
-        self.assertEquals(u"", equipment.description)
+        self.assertEqual(u"", equipment.description)
 
     @unittest.skipIf(sys.version_info > (3, 0), "All strings are unicode in Python 3")
     def test_description_set_to_non_unicode_string(self):
@@ -85,14 +85,14 @@ class EquipmentTest(unittest.TestCase):
     def test_description_set_to_unicode_string(self):
         equipment = Equipment()
         equipment.description = u"Zapatos de €100"
-        self.assertEquals(u"Zapatos de €100", equipment.description)
+        self.assertEqual(u"Zapatos de €100", equipment.description)
         
     def test_description_set_to_non_string(self):
         equipment = Equipment()
         equipment.description = 42
         self.ddbb.session.add(equipment)
         self.ddbb.session.commit()
-        self.assertEquals(u"42", equipment.description)
+        self.assertEqual(u"42", equipment.description)
             
     def test_active_defaults_to_true(self):
         equipment = Equipment()
@@ -120,14 +120,14 @@ class EquipmentTest(unittest.TestCase):
     def test_life_expectancy_set_to_integer(self):
         equipment = Equipment()
         equipment.life_expectancy = 2
-        self.assertEquals(2, equipment.life_expectancy)
+        self.assertEqual(2, equipment.life_expectancy)
             
     def test_life_expectancy_set_to_numeric_string(self):
         equipment = Equipment()
         equipment.life_expectancy = "3"
         self.ddbb.session.add(equipment)
         self.ddbb.session.commit()
-        self.assertEquals(3, equipment.life_expectancy)
+        self.assertEqual(3, equipment.life_expectancy)
 
     def test_life_expectancy_set_to_non_numeric_string(self):
         equipment = Equipment()
@@ -147,14 +147,14 @@ class EquipmentTest(unittest.TestCase):
     def test_prior_usage_set_to_integer(self):
         equipment = Equipment()
         equipment.prior_usage = 2
-        self.assertEquals(2, equipment.prior_usage)
+        self.assertEqual(2, equipment.prior_usage)
             
     def test_prior_usage_set_to_numeric_string(self):
         equipment = Equipment()
         equipment.prior_usage = "3"
         self.ddbb.session.add(equipment)
         self.ddbb.session.commit()
-        self.assertEquals(3, equipment.prior_usage)
+        self.assertEqual(3, equipment.prior_usage)
 
     def test_prior_usage_set_to_non_numeric_string(self):
         equipment = Equipment()
@@ -169,7 +169,7 @@ class EquipmentTest(unittest.TestCase):
             
     def test_notes_defaults_to_empty_string(self):
         equipment = Equipment()
-        self.assertEquals(u"", equipment.notes)
+        self.assertEqual(u"", equipment.notes)
 
     @unittest.skipIf(sys.version_info > (3, 0), "All strings are unicode in Python 3")
     def test_notes_set_to_string(self):
@@ -188,14 +188,14 @@ class EquipmentTest(unittest.TestCase):
     def test_notes_set_to_unicode_string(self):
         equipment = Equipment()
         equipment.notes = u"Zapatos de €100."
-        self.assertEquals(u"Zapatos de €100.", equipment.notes)
+        self.assertEqual(u"Zapatos de €100.", equipment.notes)
         
     def test_notes_set_to_non_string(self):
         equipment = Equipment()
         equipment.notes = 42
         self.ddbb.session.add(equipment)
         self.ddbb.session.commit()
-        self.assertEquals(u"42", equipment.notes)
+        self.assertEqual(u"42", equipment.notes)
             
     def test_equals_new_instances(self):
         equipment1 = Equipment()
@@ -236,12 +236,12 @@ class EquipmentServiceTest(unittest.TestCase):
                                            "description": u"Test Description",
                                            "prior_usage": 200, "active": True})
         item = self.equipment_service.get_equipment_item(1)
-        self.assertEquals(1, item.id)
-        self.assertEquals("Test Description", item.description)
+        self.assertEqual(1, item.id)
+        self.assertEqual("Test Description", item.description)
         self.assertTrue(item.active)
-        self.assertEquals(500, item.life_expectancy)
-        self.assertEquals(200, item.prior_usage)
-        self.assertEquals("Test notes.", item.notes)
+        self.assertEqual(500, item.life_expectancy)
+        self.assertEqual(200, item.prior_usage)
+        self.assertEqual("Test notes.", item.notes)
     
     def test_get_equipment_item_non_unicode(self):
         self.mock_ddbb.session.execute(self.equipment_table.insert(),
@@ -250,12 +250,12 @@ class EquipmentServiceTest(unittest.TestCase):
                                            "description": u"Test Description",
                                            "prior_usage": 200, "active": True})
         item = self.equipment_service.get_equipment_item(1)
-        self.assertEquals("Test Description", item.description)
-        self.assertEquals("Test notes.", item.notes)
+        self.assertEqual("Test Description", item.description)
+        self.assertEqual("Test notes.", item.notes)
     
     def test_get_equipment_item_non_existant(self):
         item = self.equipment_service.get_equipment_item(1)
-        self.assertEquals(None, item)
+        self.assertEqual(None, item)
         
     def test_get_all_equipment(self):
         self.mock_ddbb.session.execute(self.equipment_table.insert(),
@@ -270,23 +270,23 @@ class EquipmentServiceTest(unittest.TestCase):
                                            "prior_usage": 300, "active": False})
         items = self.equipment_service.get_all_equipment()
         item = items[0]
-        self.assertEquals(1, item.id)
-        self.assertEquals("Test item 1", item.description)
+        self.assertEqual(1, item.id)
+        self.assertEqual("Test item 1", item.description)
         self.assertTrue(item.active)
-        self.assertEquals(500, item.life_expectancy)
-        self.assertEquals(200, item.prior_usage)
-        self.assertEquals("Test notes 1.", item.notes)
+        self.assertEqual(500, item.life_expectancy)
+        self.assertEqual(200, item.prior_usage)
+        self.assertEqual("Test notes 1.", item.notes)
         item = items[1]
-        self.assertEquals(2, item.id)
-        self.assertEquals("Test item 2", item.description)
+        self.assertEqual(2, item.id)
+        self.assertEqual("Test item 2", item.description)
         self.assertFalse(item.active)
-        self.assertEquals(600, item.life_expectancy)
-        self.assertEquals(300, item.prior_usage)
-        self.assertEquals("Test notes 2.", item.notes)
+        self.assertEqual(600, item.life_expectancy)
+        self.assertEqual(300, item.prior_usage)
+        self.assertEqual("Test notes 2.", item.notes)
         
     def test_get_all_equipment_non_existant(self):
         items = self.equipment_service.get_all_equipment()
-        self.assertEquals([], items)
+        self.assertEqual([], items)
         
     def test_get_active_equipment(self):
         self.mock_ddbb.session.execute(self.equipment_table.insert(),
@@ -301,29 +301,29 @@ class EquipmentServiceTest(unittest.TestCase):
                                            "prior_usage": 300, "active": True})
         items = self.equipment_service.get_active_equipment()
         item = items[0]
-        self.assertEquals(1, item.id)
-        self.assertEquals("Test item 1", item.description)
+        self.assertEqual(1, item.id)
+        self.assertEqual("Test item 1", item.description)
         self.assertTrue(item.active)
-        self.assertEquals(500, item.life_expectancy)
-        self.assertEquals(200, item.prior_usage)
-        self.assertEquals("Test notes 1.", item.notes)
+        self.assertEqual(500, item.life_expectancy)
+        self.assertEqual(200, item.prior_usage)
+        self.assertEqual("Test notes 1.", item.notes)
         item = items[1]
-        self.assertEquals(2, item.id)
-        self.assertEquals("Test item 2", item.description)
+        self.assertEqual(2, item.id)
+        self.assertEqual("Test item 2", item.description)
         self.assertTrue(item.active)
-        self.assertEquals(600, item.life_expectancy)
-        self.assertEquals(300, item.prior_usage)
-        self.assertEquals("Test notes 2.", item.notes)
+        self.assertEqual(600, item.life_expectancy)
+        self.assertEqual(300, item.prior_usage)
+        self.assertEqual("Test notes 2.", item.notes)
         
     def test_get_active_equipment_non_existant(self):
         items = self.equipment_service.get_active_equipment()
-        self.assertEquals([], items)
+        self.assertEqual([], items)
         
     def test_store_equipment(self):
         equipment = Equipment()
         equipment.description = u"test description"
         stored_equipment = self.equipment_service.store_equipment(equipment)
-        self.assertEquals(1, stored_equipment.id)
+        self.assertEqual(1, stored_equipment.id)
         
     def test_store_equipment_duplicate_description(self):
         self.mock_ddbb.session.execute(self.equipment_table.insert(),
@@ -349,7 +349,7 @@ class EquipmentServiceTest(unittest.TestCase):
         equipment.description = u"new description"
         self.equipment_service.store_equipment(equipment)
         equipment = self.equipment_service.get_equipment_item(1)
-        self.assertEquals("new description", equipment.description)
+        self.assertEqual("new description", equipment.description)
         
     def test_update_equipment_duplicate_description(self):
         self.mock_ddbb.session.execute(self.equipment_table.insert(),
@@ -376,7 +376,7 @@ class EquipmentServiceTest(unittest.TestCase):
         self.mock_ddbb.session.execute("insert into record_equipment (record_id,equipment_id) values (1,1)")
         equipment = self.equipment_service.get_equipment_item(1)
         usage = self.equipment_service.get_equipment_usage(equipment)
-        self.assertEquals(250, usage)
+        self.assertEqual(250, usage)
         
     def test_get_equipment_usage_none(self):
         self.mock_ddbb.session.execute(self.equipment_table.insert(),
@@ -386,21 +386,21 @@ class EquipmentServiceTest(unittest.TestCase):
                                            "prior_usage": 0, "active": True})
         equipment = self.equipment_service.get_equipment_item(1)
         usage = self.equipment_service.get_equipment_usage(equipment)
-        self.assertEquals(0, usage)
+        self.assertEqual(0, usage)
 
     def test_get_equipment_prior_usage(self):
         equipment = Equipment()
         equipment.id = 1
         equipment.prior_usage = 250
         usage = self.equipment_service.get_equipment_usage(equipment)
-        self.assertEquals(250, usage)
+        self.assertEqual(250, usage)
 
     def test_get_equipment_prior_usage(self):
         equipment = Equipment()
         equipment.id = 1
         equipment.prior_usage = 250
         usage = self.equipment_service.get_equipment_usage(equipment)
-        self.assertEquals(250, usage)
+        self.assertEqual(250, usage)
 
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']

--- a/pytrainer/test/core/test_equipment.py
+++ b/pytrainer/test/core/test_equipment.py
@@ -17,6 +17,7 @@
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 import unittest
+import sys
 import mock
 from pytrainer.core.equipment import Equipment, EquipmentService,\
     EquipmentServiceException
@@ -66,7 +67,8 @@ class EquipmentTest(unittest.TestCase):
     def test_description_defaults_to_empty_string(self):
         equipment = Equipment()
         self.assertEquals(u"", equipment.description)
-            
+
+    @unittest.skipIf(sys.version_info > (3, 0), "All strings are unicode in Python 3")
     def test_description_set_to_non_unicode_string(self):
         if self.ddbb.engine.name == 'mysql':
             self.skipTest('Not supported on Mysql 5.6')
@@ -168,7 +170,8 @@ class EquipmentTest(unittest.TestCase):
     def test_notes_defaults_to_empty_string(self):
         equipment = Equipment()
         self.assertEquals(u"", equipment.notes)
-            
+
+    @unittest.skipIf(sys.version_info > (3, 0), "All strings are unicode in Python 3")
     def test_notes_set_to_string(self):
         if self.ddbb.engine.name == 'mysql':
             self.skipTest('Not supported on Mysql 5.6')

--- a/pytrainer/test/core/test_sport.py
+++ b/pytrainer/test/core/test_sport.py
@@ -17,6 +17,7 @@
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 import unittest
+import sys
 from pytrainer.core.sport import Sport, SportService, SportServiceException
 import mock
 import pytrainer.core
@@ -72,7 +73,8 @@ class SportTest(unittest.TestCase):
         sport = Sport()
         sport.name = u"Unicycling"
         self.assertEquals(u"Unicycling", sport.name)
-        
+
+    @unittest.skipIf(sys.version_info > (3, 0), "All strings are unicode in Python 3")
     def test_name_should_not_accept_non_unicode_string(self):
         if self.ddbb.engine.name == 'mysql':
             self.skipTest('Not supported on Mysql 5.6')

--- a/pytrainer/test/core/test_sport.py
+++ b/pytrainer/test/core/test_sport.py
@@ -37,12 +37,12 @@ class SportTest(unittest.TestCase):
     
     def test_id_should_default_to_none(self):
         sport = Sport()
-        self.assertEquals(None, sport.id)
+        self.assertEqual(None, sport.id)
         
     def test_id_should_accept_integer(self):
         sport = Sport()
         sport.id = 1
-        self.assertEquals(1, sport.id)
+        self.assertEqual(1, sport.id)
         
     def test_id_should_accept_integer_string(self):
         sport = Sport()
@@ -50,7 +50,7 @@ class SportTest(unittest.TestCase):
         self.ddbb.session.add(sport)
         self.ddbb.session.commit()
         sport = self.ddbb.session.query(Sport).filter(Sport.id == 1).one()
-        self.assertEquals(1, sport.id)
+        self.assertEqual(1, sport.id)
         
     def test_id_should_not_accept_non_integer_string(self):
         if self.ddbb.engine.name == 'mysql':
@@ -67,12 +67,12 @@ class SportTest(unittest.TestCase):
             
     def test_name_should_default_to_empty_string(self):
         sport = Sport()
-        self.assertEquals(u"", sport.name)
+        self.assertEqual(u"", sport.name)
         
     def test_name_should_accept_unicode_string(self):
         sport = Sport()
         sport.name = u"Unicycling"
-        self.assertEquals(u"Unicycling", sport.name)
+        self.assertEqual(u"Unicycling", sport.name)
 
     @unittest.skipIf(sys.version_info > (3, 0), "All strings are unicode in Python 3")
     def test_name_should_not_accept_non_unicode_string(self):
@@ -101,14 +101,14 @@ class SportTest(unittest.TestCase):
             
     def test_met_should_default_to_None(self):
         sport = Sport()
-        self.assertEquals(None, sport.met)
+        self.assertEqual(None, sport.met)
         
     def test_met_should_accept_float(self):
         sport = Sport()
         sport.met = 22.5
         self.ddbb.session.add(sport)
         self.ddbb.session.flush()
-        self.assertEquals(22.5, sport.met)
+        self.assertEqual(22.5, sport.met)
         
     def test_met_should_accept_float_string(self):
         sport = Sport()
@@ -117,7 +117,7 @@ class SportTest(unittest.TestCase):
         self.ddbb.session.add(sport)
         self.ddbb.session.commit()
         sport = self.ddbb.session.query(Sport).filter(Sport.id == 1).one()
-        self.assertEquals(22.5, sport.met)
+        self.assertEqual(22.5, sport.met)
         
     def test_met_should_not_accept_non_float_string(self):
         if self.ddbb.engine.name == 'mysql':
@@ -148,23 +148,23 @@ class SportTest(unittest.TestCase):
     def test_met_should_accept_none(self):
         sport = Sport()
         sport.met = None
-        self.assertEquals(None, sport.met)
+        self.assertEqual(None, sport.met)
             
     def test_weight_should_default_to_zero(self):
         sport = Sport()
-        self.assertEquals(0, sport.weight)
+        self.assertEqual(0, sport.weight)
         
     def test_weight_should_accept_float(self):
         sport = Sport()
         sport.weight = 22.5
-        self.assertEquals(22.5, sport.weight)
+        self.assertEqual(22.5, sport.weight)
         
     def test_weight_should_accept_float_string(self):
         sport = Sport()
         sport.weight = "22.5"
         self.ddbb.session.add(sport)
         self.ddbb.session.commit()
-        self.assertEquals(22.5, sport.weight)
+        self.assertEqual(22.5, sport.weight)
         
     def test_weight_should_not_accept_non_float_string(self):
         if self.ddbb.engine.name == 'mysql':
@@ -205,21 +205,21 @@ class SportTest(unittest.TestCase):
             
     def test_max_pace_should_default_to_none(self):
         sport = Sport()
-        self.assertEquals(None, sport.max_pace)
+        self.assertEqual(None, sport.max_pace)
         
     def test_max_pace_should_accept_integer(self):
         sport = Sport()
         sport.max_pace = 220
         self.ddbb.session.add(sport)
         self.ddbb.session.flush()
-        self.assertEquals(220, sport.max_pace)
+        self.assertEqual(220, sport.max_pace)
         
     def test_max_pace_should_accept_integer_string(self):
         sport = Sport()
         sport.max_pace = "220"
         self.ddbb.session.add(sport)
         self.ddbb.session.commit()
-        self.assertEquals(220, sport.max_pace)
+        self.assertEqual(220, sport.max_pace)
         
     def test_max_pace_should_not_accept_non_integer_string(self):
         sport = Sport()
@@ -238,7 +238,7 @@ class SportTest(unittest.TestCase):
         self.ddbb.session.add(sport)
         self.ddbb.session.commit()
         sport = self.ddbb.session.query(Sport).filter(Sport.id == 1).one()
-        self.assertEquals(220, sport.max_pace)
+        self.assertEqual(220, sport.max_pace)
 
     def test_max_pace_should_not_accept_negative_value(self):
         if self.ddbb.engine.name == 'mysql':
@@ -256,11 +256,11 @@ class SportTest(unittest.TestCase):
     def test_max_pace_should_accept_none(self):
         sport = Sport()
         sport.max_pace = None
-        self.assertEquals(None, sport.max_pace)
+        self.assertEqual(None, sport.max_pace)
         
     def test_color_should_default_to_blue(self):
         sport = Sport()
-        self.assertEquals(0x0000ff, sport.color.rgb_val)
+        self.assertEqual(0x0000ff, sport.color.rgb_val)
         
     def test_color_should_not_accept_none(self):
         sport = Sport()
@@ -290,7 +290,7 @@ class SportServiceTest(unittest.TestCase):
         sport = Sport()
         sport.name = u"Test name"
         sport = self.sport_service.store_sport(sport)
-        self.assertEquals(1, sport.id)
+        self.assertEqual(1, sport.id)
 
     
     def test_store_sport_should_update_row_when_sport_has_id(self):
@@ -300,12 +300,12 @@ class SportServiceTest(unittest.TestCase):
         sport.name = u"New name"
         self.sport_service.store_sport(sport)
         sport = self.sport_service.get_sport(1)
-        self.assertEquals(sport.name, u"New name")
+        self.assertEqual(sport.name, u"New name")
         
     def test_store_sport_should_return_stored_sport(self):
         sport = Sport()
         stored_sport = self.sport_service.store_sport(sport)
-        self.assertEquals(1, stored_sport.id)
+        self.assertEqual(1, stored_sport.id)
     
     def test_store_sport_should_error_when_new_sport_has_duplicate_name(self):
         sport1 = Sport()
@@ -337,14 +337,14 @@ class SportServiceTest(unittest.TestCase):
     
     def test_get_sport_returns_none_for_nonexistant_sport(self):
         sport = self.sport_service.get_sport(1)
-        self.assertEquals(None, sport)
+        self.assertEqual(None, sport)
         
     def test_get_sport_returns_sport_with_id(self):
         sport = Sport()
         sport.name = u"Test name"
         self.sport_service.store_sport(sport)
         sport = self.sport_service.get_sport(1)
-        self.assertEquals(1, sport.id)
+        self.assertEqual(1, sport.id)
         
     def test_get_sport_raises_error_for_id_none(self):
         try:
@@ -356,14 +356,14 @@ class SportServiceTest(unittest.TestCase):
         
     def test_get_sport_by_name_returns_none_for_nonexistant_sport(self):
         sport = self.sport_service.get_sport_by_name("no such sport")
-        self.assertEquals(None, sport)
+        self.assertEqual(None, sport)
         
     def test_get_sport_by_name_returns_sport_with_name(self):
         sport1 = Sport()
         sport1.name = u"rugby"
         self.sport_service.store_sport(sport1)
         sport2 = self.sport_service.get_sport_by_name("rugby")
-        self.assertEquals(u"rugby", sport2.name)
+        self.assertEqual(u"rugby", sport2.name)
         
     def test_get_sport_by_name_raises_error_for_none_sport_name(self):
         try:
@@ -381,15 +381,15 @@ class SportServiceTest(unittest.TestCase):
         sport2.name = u"Test name 2"
         self.sport_service.store_sport(sport2)
         sports = self.sport_service.get_all_sports()
-        self.assertEquals(2, len(sports))
+        self.assertEqual(2, len(sports))
         sport1 = sports[0]
-        self.assertEquals(1, sport1.id)
+        self.assertEqual(1, sport1.id)
         sport2 = sports[1]
-        self.assertEquals(2, sport2.id)
+        self.assertEqual(2, sport2.id)
     
     def test_get_all_sports_should_return_no_sports_when_query_result_empty(self):
         sports = self.sport_service.get_all_sports()
-        self.assertEquals(0, len(sports))
+        self.assertEqual(0, len(sports))
         
     def test_remove_sport_should_error_when_sport_has_no_id(self):
         sport = Sport()
@@ -416,4 +416,4 @@ class SportServiceTest(unittest.TestCase):
         sport = self.sport_service.store_sport(sport)
         self.sport_service.remove_sport(sport)
         result = self.sport_service.get_sport(1)
-        self.assertEquals(result, None)
+        self.assertEqual(result, None)

--- a/pytrainer/test/gui/test_color.py
+++ b/pytrainer/test/gui/test_color.py
@@ -29,9 +29,9 @@ class ColorConverterTest(unittest.TestCase):
     def test_convert_to_gdk_color_should_create_gdk_color_with_equivalent_rgb_values(self):
         color = Color(0xaaff33)
         gdk_color = self._converter.convert_to_gdk_color(color)
-        self.assertEquals(0x3333, gdk_color.blue)
-        self.assertEquals(0xffff, gdk_color.green)
-        self.assertEquals(0xaaaa, gdk_color.red)
+        self.assertEqual(0x3333, gdk_color.blue)
+        self.assertEqual(0xffff, gdk_color.green)
+        self.assertEqual(0xaaaa, gdk_color.red)
         
     def test_convert_to_color_should_create_color_with_equivalent_rgb_values(self):
         gdk_col = Gdk.color_parse("#aaff33")

--- a/pytrainer/test/gui/test_equipment.py
+++ b/pytrainer/test/gui/test_equipment.py
@@ -38,7 +38,7 @@ class EquipmentStoreTest(TestCase):
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
-        self.assertEquals(1, equipment_store.get_value(iter, 0))
+        self.assertEqual(1, equipment_store.get_value(iter, 0))
         
     def test_get_item_description(self):
         equipment = Equipment()
@@ -47,7 +47,7 @@ class EquipmentStoreTest(TestCase):
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
-        self.assertEquals("item description", equipment_store.get_value(iter, 1))
+        self.assertEqual("item description", equipment_store.get_value(iter, 1))
         
     def test_get_item_usage_percent(self):
         equipment = Equipment()
@@ -57,7 +57,7 @@ class EquipmentStoreTest(TestCase):
         self.mock_equipment_service.get_equipment_usage.return_value = 100
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
-        self.assertEquals(50, equipment_store.get_value(iter, 2))
+        self.assertEqual(50, equipment_store.get_value(iter, 2))
         
     def test_get_item_usage_percent_prior_usage(self):
         equipment = Equipment()
@@ -68,7 +68,7 @@ class EquipmentStoreTest(TestCase):
         self.mock_equipment_service.get_equipment_usage.return_value = 100
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
-        self.assertEquals(75, equipment_store.get_value(iter, 2))
+        self.assertEqual(75, equipment_store.get_value(iter, 2))
         
     def test_get_item_usage_percent_zero_usage(self):
         equipment = Equipment()
@@ -78,7 +78,7 @@ class EquipmentStoreTest(TestCase):
         self.mock_equipment_service.get_equipment_usage.return_value = 0
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
-        self.assertEquals(0, equipment_store.get_value(iter, 2))
+        self.assertEqual(0, equipment_store.get_value(iter, 2))
         
     def test_get_item_usage_percent_usage_exceeds_life_expectancy(self):
         equipment = Equipment()
@@ -88,7 +88,7 @@ class EquipmentStoreTest(TestCase):
         self.mock_equipment_service.get_equipment_usage.return_value = 300
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
-        self.assertEquals(100, equipment_store.get_value(iter, 2), "Progress bar cannot exceed 100%.")
+        self.assertEqual(100, equipment_store.get_value(iter, 2), "Progress bar cannot exceed 100%.")
         
         
     def test_get_item_usage_text(self):
@@ -99,7 +99,7 @@ class EquipmentStoreTest(TestCase):
         self.mock_equipment_service.get_equipment_usage.return_value = 100
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
-        self.assertEquals("100 / 200", equipment_store.get_value(iter, 3))
+        self.assertEqual("100 / 200", equipment_store.get_value(iter, 3))
         
     def test_get_item_usage_text_rounded(self):
         equipment = Equipment()
@@ -109,7 +109,7 @@ class EquipmentStoreTest(TestCase):
         self.mock_equipment_service.get_equipment_usage.return_value = 100.6
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
-        self.assertEquals("101 / 200", equipment_store.get_value(iter, 3))
+        self.assertEqual("101 / 200", equipment_store.get_value(iter, 3))
         
     def test_get_item_usage_text_prior_usage(self):
         equipment = Equipment()
@@ -120,7 +120,7 @@ class EquipmentStoreTest(TestCase):
         self.mock_equipment_service.get_equipment_usage.return_value = 100
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
-        self.assertEquals("150 / 200", equipment_store.get_value(iter, 3))
+        self.assertEqual("150 / 200", equipment_store.get_value(iter, 3))
         
     def test_get_item_usage_text_zero_usage(self):
         equipment = Equipment()
@@ -130,7 +130,7 @@ class EquipmentStoreTest(TestCase):
         self.mock_equipment_service.get_equipment_usage.return_value = 0
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
-        self.assertEquals("0 / 200", equipment_store.get_value(iter, 3))
+        self.assertEqual("0 / 200", equipment_store.get_value(iter, 3))
         
     def test_get_item_usage_text_usage_exceeds_life_expectancy(self):
         equipment = Equipment()
@@ -140,7 +140,7 @@ class EquipmentStoreTest(TestCase):
         self.mock_equipment_service.get_equipment_usage.return_value = 300
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
-        self.assertEquals("300 / 200", equipment_store.get_value(iter, 3))
+        self.assertEqual("300 / 200", equipment_store.get_value(iter, 3))
         
     def test_get_item_active(self):
         equipment = Equipment()
@@ -160,7 +160,7 @@ class EquipmentStoreTest(TestCase):
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
         iter = equipment_store.iter_next(iter)
-        self.assertEquals(2, equipment_store.get_value(iter, 0))
+        self.assertEqual(2, equipment_store.get_value(iter, 0))
         
 class EquipmentUiTest(TestCase):
 

--- a/pytrainer/test/gui/test_equipment.py
+++ b/pytrainer/test/gui/test_equipment.py
@@ -106,7 +106,7 @@ class EquipmentStoreTest(TestCase):
         equipment.id = 1
         equipment.life_expectancy = 200
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
-        self.mock_equipment_service.get_equipment_usage.return_value = 100.5
+        self.mock_equipment_service.get_equipment_usage.return_value = 100.6
         equipment_store = EquipmentStore(self.mock_equipment_service)
         iter = equipment_store.get_iter_first()
         self.assertEquals("101 / 200", equipment_store.get_value(iter, 3))

--- a/pytrainer/test/imports/test_garmintcxv2.py
+++ b/pytrainer/test/imports/test_garmintcxv2.py
@@ -47,7 +47,7 @@ class GarminTCXv2Test(unittest.TestCase):
             garmin_tcxv2 = garmintcxv2(self.parent, data_path)
             garmin_tcxv2.xmldoc = etree.parse(tcx_file)
             garmin_tcxv2.buildActivitiesSummary()
-            self.assertEquals(summary, garmin_tcxv2.activitiesSummary)
+            self.assertEqual(summary, garmin_tcxv2.activitiesSummary)
         except():
             self.fail()
 
@@ -62,7 +62,7 @@ class GarminTCXv2Test(unittest.TestCase):
         garmin_tcxv2 = garmintcxv2(self.parent, data_path)
         garmin_tcxv2.xmldoc = etree.parse(tcx_file)
         garmin_tcxv2.buildActivitiesSummary()
-        self.assertEquals(summary, garmin_tcxv2.activitiesSummary)
+        self.assertEqual(summary, garmin_tcxv2.activitiesSummary)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pytrainer/test/lib/test_date.py
+++ b/pytrainer/test/lib/test_date.py
@@ -100,11 +100,11 @@ class DateRangeTest(unittest.TestCase):
 
     def test_start_date_should_return_constructed_Value(self):
         date_range = DateRange(datetime.date(2011, 9, 28), datetime.date(2011, 9, 29))
-        self.assertEquals(datetime.date(2011, 9, 28), date_range.start_date)
+        self.assertEqual(datetime.date(2011, 9, 28), date_range.start_date)
 
     def test_end_date_should_return_constructed_Value(self):
         date_range = DateRange(datetime.date(2011, 9, 28), datetime.date(2011, 9, 29))
-        self.assertEquals(datetime.date(2011, 9, 29), date_range.end_date)
+        self.assertEqual(datetime.date(2011, 9, 29), date_range.end_date)
 
     def test_start_date_should_be_immutable(self):
         date_range = DateRange(datetime.date(2011, 9, 28), datetime.date(2011, 9, 29))
@@ -126,28 +126,28 @@ class DateRangeTest(unittest.TestCase):
 
     def test_date_range_for_year_should_start_jan_1(self):
         date_range = DateRange.for_year_containing(datetime.date(2011, 12, 11))
-        self.assertEquals(datetime.date(2011, 1, 1), date_range.start_date)
+        self.assertEqual(datetime.date(2011, 1, 1), date_range.start_date)
 
     def test_date_range_for_year_should_end_dec_31(self):
         date_range = DateRange.for_year_containing(datetime.date(2011, 12, 11))
-        self.assertEquals(datetime.date(2011, 12, 31), date_range.end_date)
+        self.assertEqual(datetime.date(2011, 12, 31), date_range.end_date)
 
     def test_date_range_for_month_should_start_first_day_of_month(self):
         date_range = DateRange.for_month_containing(datetime.date(2011, 12, 11))
-        self.assertEquals(datetime.date(2011, 12, 1), date_range.start_date)
+        self.assertEqual(datetime.date(2011, 12, 1), date_range.start_date)
 
     def test_date_range_for_month_dec_should_end_dec_31(self):
         date_range = DateRange.for_month_containing(datetime.date(2011, 12, 11))
-        self.assertEquals(datetime.date(2011, 12, 31), date_range.end_date)
+        self.assertEqual(datetime.date(2011, 12, 31), date_range.end_date)
 
     def test_date_range_for_month_feb_should_end_feb_28(self):
         date_range = DateRange.for_month_containing(datetime.date(2011, 2, 11))
-        self.assertEquals(datetime.date(2011, 2, 28), date_range.end_date)
+        self.assertEqual(datetime.date(2011, 2, 28), date_range.end_date)
 
     def test_date_range_for_week_should_start_sunday(self):
         date_range = DateRange.for_week_containing(datetime.date(2011, 12, 7))
-        self.assertEquals(datetime.date(2011, 12, 4), date_range.start_date)
+        self.assertEqual(datetime.date(2011, 12, 4), date_range.start_date)
 
     def test_date_range_for_week_should_end_saturday(self):
         date_range = DateRange.for_week_containing(datetime.date(2011, 12, 7))
-        self.assertEquals(datetime.date(2011, 12, 10), date_range.end_date)
+        self.assertEqual(datetime.date(2011, 12, 10), date_range.end_date)

--- a/pytrainer/test/lib/test_gpx.py
+++ b/pytrainer/test/lib/test_gpx.py
@@ -47,7 +47,7 @@ class GpxTest(unittest.TestCase):
             gpx = Gpx(None, None) # avoid launching _getValues
             gpx.tree = etree.ElementTree(file = xml_file).getroot()
             gpx_laps = gpx.getLaps()
-            self.assertEquals(orig_laps, gpx_laps)
+            self.assertEqual(orig_laps, gpx_laps)
         except():
             self.fail()
 
@@ -69,7 +69,7 @@ class GpxTest(unittest.TestCase):
             gpx = Gpx(None, None) # avoid launching _getValues
             gpx.tree = etree.ElementTree(file = xml_file).getroot()
             gpx_laps = gpx.getLaps()
-            self.assertEquals(orig_laps, gpx_laps)
+            self.assertEqual(orig_laps, gpx_laps)
         except():
             self.fail()
 

--- a/pytrainer/test/lib/test_gpx.py
+++ b/pytrainer/test/lib/test_gpx.py
@@ -19,6 +19,7 @@
 
 import unittest
 import os
+from tempfile import NamedTemporaryFile
 from lxml import etree
 from pytrainer.lib.gpx import Gpx
 
@@ -79,14 +80,12 @@ class GpxTest(unittest.TestCase):
 """
         
         # Write a GPX file with no tracks
-        file_name = "test-missing.gpx"
-        tmpf = file(file_name,'w')
-        tmpf.write(trkdata)
-        tmpf.close()
-        self.tmp_files.append(file_name)
+        with NamedTemporaryFile(mode='w', delete=False) as tmpf:
+            tmpf.write(trkdata)
+        self.tmp_files.append(tmpf.name)
         
         try:
-            g = Gpx(filename=file_name)
+            g = Gpx(filename=tmpf.name)
         except IndexError:
             self.fail("Gpx parser crashed on file without tracks")
 
@@ -98,14 +97,12 @@ class GpxTest(unittest.TestCase):
 """
         
         # Write a GPX file with a nameless track
-        file_name = "test-noname.gpx"
-        tmpf = file(file_name,'w')
-        tmpf.write(trkdata)
-        tmpf.close()
-        self.tmp_files.append(file_name)
+        with NamedTemporaryFile(mode='w', delete=False) as tmpf:
+            tmpf.write(trkdata)
+        self.tmp_files.append(tmpf.name)
         
         try:
-            g = Gpx(filename=file_name)
+            g = Gpx(filename=tmpf.name)
         except IndexError:
             self.fail("Gpx parser crashed on file with a nameless track")
 

--- a/pytrainer/test/lib/test_uc.py
+++ b/pytrainer/test/lib/test_uc.py
@@ -23,10 +23,10 @@ from pytrainer.lib.uc import *
 class UCUtilTest(unittest.TestCase):
 
     def test_uc_pace2float(self):
-        self.assertEquals(4.1, pace2float('4:06'))
+        self.assertEqual(4.1, pace2float('4:06'))
 
     def test_uc_float2pace(self):
-        self.assertEquals('4:06', float2pace(4.1))
+        self.assertEqual('4:06', float2pace(4.1))
 
 class UCTest(unittest.TestCase):
 
@@ -38,27 +38,27 @@ class UCTest(unittest.TestCase):
         self.uc = None
 
     def test_uc_units(self):
-        self.assertEquals(self.uc.unit_distance, "km")
-        self.assertEquals(self.uc.unit_speed, "km/h")
-        self.assertEquals(self.uc.unit_pace, "min/km")
-        self.assertEquals(self.uc.unit_height, "m")
-        self.assertEquals(self.uc.unit_weight, "kg")
+        self.assertEqual(self.uc.unit_distance, "km")
+        self.assertEqual(self.uc.unit_speed, "km/h")
+        self.assertEqual(self.uc.unit_pace, "min/km")
+        self.assertEqual(self.uc.unit_height, "m")
+        self.assertEqual(self.uc.unit_weight, "kg")
         self.uc.set_us(True)
-        self.assertEquals(self.uc.unit_distance, "mi")
-        self.assertEquals(self.uc.unit_speed, "mph")
-        self.assertEquals(self.uc.unit_pace, "min/mi")
-        self.assertEquals(self.uc.unit_height, "ft")
-        self.assertEquals(self.uc.unit_weight, "lb")
+        self.assertEqual(self.uc.unit_distance, "mi")
+        self.assertEqual(self.uc.unit_speed, "mph")
+        self.assertEqual(self.uc.unit_pace, "min/mi")
+        self.assertEqual(self.uc.unit_height, "ft")
+        self.assertEqual(self.uc.unit_weight, "lb")
 
     def test_uc_conversions(self):
-        self.assertEquals(self.uc.distance(10), 10)
-        self.assertEquals(self.uc.speed(10), 10)
-        self.assertEquals(self.uc.pace(10), 10)
-        self.assertEquals(self.uc.height(10), 10)
-        self.assertEquals(self.uc.weight(10), 10)
+        self.assertEqual(self.uc.distance(10), 10)
+        self.assertEqual(self.uc.speed(10), 10)
+        self.assertEqual(self.uc.pace(10), 10)
+        self.assertEqual(self.uc.height(10), 10)
+        self.assertEqual(self.uc.weight(10), 10)
         self.uc.set_us(True)
-        self.assertEquals(self.uc.distance(10), 6.21371192)
-        self.assertEquals(self.uc.speed(10), 6.21371192)
-        self.assertEquals(self.uc.pace(10), 16.09344)
-        self.assertEquals(self.uc.height(10), 32.808399)
-        self.assertEquals(self.uc.weight(10), 22.046239999999997)
+        self.assertEqual(self.uc.distance(10), 6.21371192)
+        self.assertEqual(self.uc.speed(10), 6.21371192)
+        self.assertEqual(self.uc.pace(10), 16.09344)
+        self.assertEqual(self.uc.height(10), 32.808399)
+        self.assertEqual(self.uc.weight(10), 22.046239999999997)

--- a/pytrainer/test/plugins/test_garmin-tcxv2.py
+++ b/pytrainer/test/plugins/test_garmin-tcxv2.py
@@ -37,4 +37,4 @@ class GarminTCXv2PluginTest(unittest.TestCase):
         self.assertTrue(self.plugin.inDatabase(self.activity))
 
     def test_detailsFromTCX(self):
-        self.assertEquals(self.plugin.detailsFromTCX(self.activity), '2012-10-14T10:02:42.000Z')
+        self.assertEqual(self.plugin.detailsFromTCX(self.activity), '2012-10-14T10:02:42.000Z')

--- a/pytrainer/test/test_athlete.py
+++ b/pytrainer/test/test_athlete.py
@@ -45,7 +45,7 @@ class AthleteTest(unittest.TestCase):
                                           data['bodyfat'], data['restinghr'],
                                           data['maxhr'])
         data2 = self.athlete.get_athlete_stats()
-        self.assertEquals(data, data2[0])
+        self.assertEqual(data, data2[0])
 
     def test_athlete_update_and_get(self):
         data = {'date': date(2017, 4, 3), 'weight': 60.0, 'bodyfat': 20.0,
@@ -59,7 +59,7 @@ class AthleteTest(unittest.TestCase):
                                           data['bodyfat'], data['restinghr'],
                                           data['maxhr'])
         data2 = self.athlete.get_athlete_stats()
-        self.assertEquals(data, data2[0])
+        self.assertEqual(data, data2[0])
 
     def test_athlete_delete_record(self):
         data = {'date': date(2017, 4, 3), 'weight': 60.0, 'bodyfat': 20.0,

--- a/pytrainer/test/test_environment.py
+++ b/pytrainer/test/test_environment.py
@@ -37,33 +37,33 @@ class Test(unittest.TestCase):
         del(Environment.self)
 
     def test_get_conf_dir(self):
-        self.assertEquals(TEST_DIR_NAME, self.environment.conf_dir)
+        self.assertEqual(TEST_DIR_NAME, self.environment.conf_dir)
 
     def test_get_data_path(self):
-        self.assertEquals(DATA_DIR_NAME, self.environment.data_path)
+        self.assertEqual(DATA_DIR_NAME, self.environment.data_path)
 
     def test_environment_singleton(self):
         self.environment = Environment()
-        self.assertEquals(TEST_DIR_NAME, self.environment.conf_dir)
-        self.assertEquals(DATA_DIR_NAME, self.environment.data_path)
+        self.assertEqual(TEST_DIR_NAME, self.environment.conf_dir)
+        self.assertEqual(DATA_DIR_NAME, self.environment.data_path)
         
     def test_get_conf_file(self):
-        self.assertEquals(TEST_DIR_NAME + "/conf.xml", self.environment.conf_file)
+        self.assertEqual(TEST_DIR_NAME + "/conf.xml", self.environment.conf_file)
 
     def test_get_log_file(self):
-        self.assertEquals(TEST_DIR_NAME + "/log.out", self.environment.log_file)
+        self.assertEqual(TEST_DIR_NAME + "/log.out", self.environment.log_file)
 
     def test_get_temp_dir(self):
-        self.assertEquals(TEST_DIR_NAME + "/tmp", self.environment.temp_dir)
+        self.assertEqual(TEST_DIR_NAME + "/tmp", self.environment.temp_dir)
 
     def test_get_gpx_dir(self):
-        self.assertEquals(TEST_DIR_NAME + "/gpx", self.environment.gpx_dir)
+        self.assertEqual(TEST_DIR_NAME + "/gpx", self.environment.gpx_dir)
 
     def test_get_extension_dir(self):
-        self.assertEquals(TEST_DIR_NAME + "/extensions", self.environment.extension_dir)
+        self.assertEqual(TEST_DIR_NAME + "/extensions", self.environment.extension_dir)
 
     def test_get_plugin_dir(self):
-        self.assertEquals(TEST_DIR_NAME + "/plugins", self.environment.plugin_dir)
+        self.assertEqual(TEST_DIR_NAME + "/plugins", self.environment.plugin_dir)
         
 
 if __name__ == "__main__":

--- a/pytrainer/test/test_record.py
+++ b/pytrainer/test/test_record.py
@@ -73,16 +73,16 @@ class RecordTest(unittest.TestCase):
     def test_insert_record(self):
         newid = self.record.insertRecord(self.summary, laps=self.laps)
         activity = self.main.activitypool.get_activity(newid)
-        self.assertEquals(activity.unegative, 564.1)
-        self.assertEquals(activity.upositive, 553.1)
-        self.assertEquals(activity.beats, 115.0)
-        self.assertEquals(activity.maxbeats, 120)
-        self.assertEquals(activity.date_time, datetime(2016, 7, 24, 12, 58, 23,
+        self.assertEqual(activity.unegative, 564.1)
+        self.assertEqual(activity.upositive, 553.1)
+        self.assertEqual(activity.beats, 115.0)
+        self.assertEqual(activity.maxbeats, 120)
+        self.assertEqual(activity.date_time, datetime(2016, 7, 24, 12, 58, 23,
                                                        tzinfo=tzoffset(None, 10800)))
-        self.assertEquals(activity.date_time_utc, u'2016-07-24T09:58:23Z')
-        self.assertEquals(activity.sport, self.record._sport_service.get_sport_by_name(u"Run"))
-        self.assertEquals(activity.title, u'test 1')
-        self.assertEquals(activity.laps[0], {'distance': 46181.9, 'end_lon': None, 'lap_number': 0, 'start_lon': None, 'id_lap': 1, 'calories': 1462, 'comments': None, 'laptrigger': u'manual', 'elapsed_time': u'7426.0', 'record': 1, 'intensity': u'active', 'avg_hr': 136, 'max_hr': 173, 'end_lat': None, 'start_lat': None, 'max_speed': None})
+        self.assertEqual(activity.date_time_utc, u'2016-07-24T09:58:23Z')
+        self.assertEqual(activity.sport, self.record._sport_service.get_sport_by_name(u"Run"))
+        self.assertEqual(activity.title, u'test 1')
+        self.assertEqual(activity.laps[0], {'distance': 46181.9, 'end_lon': None, 'lap_number': 0, 'start_lon': None, 'id_lap': 1, 'calories': 1462, 'comments': None, 'laptrigger': u'manual', 'elapsed_time': u'7426.0', 'record': 1, 'intensity': u'active', 'avg_hr': 136, 'max_hr': 173, 'end_lat': None, 'start_lat': None, 'max_speed': None})
 
     def test_insert_record_datetime(self):
         """Importing multiple activities uses a datetime object for
@@ -90,16 +90,16 @@ list_options['date_time_local'], also test that code path"""
         self.summary['date_time_local'] = datetime(2016, 7, 24, 12, 58, 23, tzinfo=tzoffset(None, 10800))
         newid = self.record.insertRecord(self.summary, laps=self.laps)
         activity = self.main.activitypool.get_activity(newid)
-        self.assertEquals(activity.unegative, 564.1)
-        self.assertEquals(activity.upositive, 553.1)
-        self.assertEquals(activity.beats, 115.0)
-        self.assertEquals(activity.maxbeats, 120)
-        self.assertEquals(activity.date_time, datetime(2016, 7, 24, 12, 58, 23,
+        self.assertEqual(activity.unegative, 564.1)
+        self.assertEqual(activity.upositive, 553.1)
+        self.assertEqual(activity.beats, 115.0)
+        self.assertEqual(activity.maxbeats, 120)
+        self.assertEqual(activity.date_time, datetime(2016, 7, 24, 12, 58, 23,
                                                        tzinfo=tzoffset(None, 10800)))
-        self.assertEquals(activity.date_time_utc, u'2016-07-24T09:58:23Z')
-        self.assertEquals(activity.sport, self.record._sport_service.get_sport_by_name(u"Run"))
-        self.assertEquals(activity.title, u'test 1')
-        self.assertEquals(activity.laps[0], {'distance': 46181.9, 'end_lon': None, 'lap_number': 0, 'start_lon': None, 'id_lap': 1, 'calories': 1462, 'comments': None, 'laptrigger': u'manual', 'elapsed_time': u'7426.0', 'record': 1, 'intensity': u'active', 'avg_hr': 136, 'max_hr': 173, 'end_lat': None, 'start_lat': None, 'max_speed': None})
+        self.assertEqual(activity.date_time_utc, u'2016-07-24T09:58:23Z')
+        self.assertEqual(activity.sport, self.record._sport_service.get_sport_by_name(u"Run"))
+        self.assertEqual(activity.title, u'test 1')
+        self.assertEqual(activity.laps[0], {'distance': 46181.9, 'end_lon': None, 'lap_number': 0, 'start_lon': None, 'id_lap': 1, 'calories': 1462, 'comments': None, 'laptrigger': u'manual', 'elapsed_time': u'7426.0', 'record': 1, 'intensity': u'active', 'avg_hr': 136, 'max_hr': 173, 'end_lat': None, 'start_lat': None, 'max_speed': None})
 
     def test_update_record(self):
         newid = self.record.insertRecord(self.summary)
@@ -108,13 +108,13 @@ list_options['date_time_local'], also test that code path"""
         update_dict['rcd_sport'] = u"Bike"
         self.record.updateRecord(update_dict, newid)
         activity = self.main.activitypool.get_activity(newid)
-        self.assertEquals(activity.title, u'test 2')
-        self.assertEquals(activity.sport, self.record._sport_service.get_sport_by_name(u"Bike"))
+        self.assertEqual(activity.title, u'test 2')
+        self.assertEqual(activity.sport, self.record._sport_service.get_sport_by_name(u"Bike"))
 
     def test_get_day_list(self):
         self.record.insertRecord(self.summary)
         daylist = list(self.record.getRecordDayList(datetime(2016, 7, 24, 9, 58, 23)))
-        self.assertEquals(daylist, [24])
+        self.assertEqual(daylist, [24])
 
     def test_getLastRecordDateString(self):
         self.record.insertRecord(self.summary)

--- a/pytrainer/test/test_waypoint.py
+++ b/pytrainer/test/test_waypoint.py
@@ -42,7 +42,7 @@ class WaypointTest(unittest.TestCase):
                                          name=data[5], comment=data[3],
                                          sym=data[6])
         data2 = self.waypoint.getwaypointInfo(dbid)
-        self.assertEquals(data, data2[0])
+        self.assertEqual(data, data2[0])
 
     def test_waypoint_update(self):
         data = (30.0, 20.0, None, u'Comment', None, u'Test', u'sym')
@@ -51,7 +51,7 @@ class WaypointTest(unittest.TestCase):
         self.waypoint.updateWaypoint(dbid, data[0], data[1], data[5], data[3],
                                      data[6])
         data2 = self.waypoint.getwaypointInfo(dbid)
-        self.assertEquals(data, data2[0])
+        self.assertEqual(data, data2[0])
 
     def test_waypoint_get_all(self):
         data = (30.0, 20.0, None, u'Comment', None, u'Test', u'sym')
@@ -60,7 +60,7 @@ class WaypointTest(unittest.TestCase):
                                          sym=data[6])
         dbid = self.waypoint.addWaypoint(lat=50, lon=60, name='Test2',
                                          comment='Comment 2', sym='sym2')
-        self.assertEquals(len(self.waypoint.getAllWaypoints()), 2)
+        self.assertEqual(len(self.waypoint.getAllWaypoints()), 2)
 
     def test_waypoint_remove(self):
         data = (30.0, 20.0, None, u'Comment', None, u'Test', u'sym')
@@ -70,4 +70,4 @@ class WaypointTest(unittest.TestCase):
         dbid = self.waypoint.addWaypoint(lat=50, lon=60, name='Test2',
                                          comment='Comment 2', sym='sym2')
         self.waypoint.removeWaypoint(dbid)
-        self.assertEquals(len(self.waypoint.getAllWaypoints()), 1)
+        self.assertEqual(len(self.waypoint.getAllWaypoints()), 1)

--- a/pytrainer/test/upgrade/test_data.py
+++ b/pytrainer/test/upgrade/test_data.py
@@ -32,37 +32,37 @@ class InstalledDataTest(unittest.TestCase):
         
     def test_get_version_should_return_migrate_version_when_available(self):
         self._mock_migratable_db.get_version.return_value = 1
-        self.assertEquals(1, self._installed_data.get_version())
+        self.assertEqual(1, self._installed_data.get_version())
         
     def test_get_version_should_return_legacy_version_when_available(self):
         self._mock_migratable_db.is_versioned.return_value = False
         self._mock_version_provider.get_legacy_version.return_value = 2
-        self.assertEquals(2, self._installed_data.get_version())
+        self.assertEqual(2, self._installed_data.get_version())
         
     def test_get_version_should_return_none_when_no_existing_version(self):
         self._mock_migratable_db.is_versioned.return_value = False
         self._mock_version_provider.get_legacy_version.return_value = None
-        self.assertEquals(None, self._installed_data.get_version())
+        self.assertEqual(None, self._installed_data.get_version())
         
     def test_get_state_should_return_current_when_data_version_equals_repository_version(self):
         self._mock_migratable_db.get_version.return_value = 1
         self._mock_migratable_db.get_upgrade_version.return_value = 1
-        self.assertEquals(DataState.CURRENT, self._installed_data.get_state())
+        self.assertEqual(DataState.CURRENT, self._installed_data.get_state())
 
     def test_get_state_should_return_fresh_when_data_version_unavailable(self):
         self._mock_migratable_db.is_versioned.return_value = False
         self._mock_version_provider.get_legacy_version.return_value = None
-        self.assertEquals(DataState.FRESH, self._installed_data.get_state())
+        self.assertEqual(DataState.FRESH, self._installed_data.get_state())
 
     def test_get_state_should_return_stale_when_data_version_less_than_repository_version(self):
         self._mock_migratable_db.get_version.return_value = 1
         self._mock_migratable_db.get_upgrade_version.return_value = 2
-        self.assertEquals(DataState.STALE, self._installed_data.get_state())
+        self.assertEqual(DataState.STALE, self._installed_data.get_state())
 
     def test_get_state_should_return_legacy_when_data_version_is_legacy(self):
         self._mock_migratable_db.is_versioned.return_value = False
         self._mock_version_provider.get_legacy_version.return_value = 1
-        self.assertEquals(DataState.LEGACY, self._installed_data.get_state())
+        self.assertEqual(DataState.LEGACY, self._installed_data.get_state())
 
     def test_get_state_should_raise_error_when_version_too_large(self):
         self._mock_migratable_db.is_versioned.return_value = True
@@ -77,11 +77,11 @@ class InstalledDataTest(unittest.TestCase):
             
     def test_get_available_version_returns_migratable_db_upgrade_version(self):
         self._mock_migratable_db.get_upgrade_version.return_value = 1
-        self.assertEquals(1, self._installed_data.get_available_version())
+        self.assertEqual(1, self._installed_data.get_available_version())
         
     def test_is_versioned_returns_migratable_db_is_versioned(self):
         self._mock_migratable_db.is_versioned.return_value = True
-        self.assertEquals(True, self._installed_data.is_versioned())
+        self.assertEqual(True, self._installed_data.is_versioned())
         
     def test_initialize_version_versions_migratable_db(self):
         self._installed_data.initialize_version(1)

--- a/pytrainer/test/util/test_color.py
+++ b/pytrainer/test/util/test_color.py
@@ -76,12 +76,12 @@ class ColorTest(unittest.TestCase):
             
     def test_rgba_value_should_be_rgb_value_with_two_trailing_zero_hex_digits(self):
         color = Color(0x1177ff)
-        self.assertEquals(0x1177ff00, color.rgba_val)
+        self.assertEqual(0x1177ff00, color.rgba_val)
         
     def test_to_hex_string_should_create_six_digit_hex_value(self):
         color = Color(0xfab)
-        self.assertEquals("000fab", color.to_hex_string())
+        self.assertEqual("000fab", color.to_hex_string())
         
     def test_color_from_hex_string_should_correctly_decode_hex_value(self):
         color = color_from_hex_string("fab")
-        self.assertEquals(0xfab, color.rgb_val)
+        self.assertEqual(0xfab, color.rgb_val)

--- a/pytrainer/totalgraph.py
+++ b/pytrainer/totalgraph.py
@@ -16,7 +16,7 @@
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-from timegraph import TimeGraph
+from .timegraph import TimeGraph
 
 class TotalGraph(TimeGraph):
 

--- a/pytrainer/totalgraph.py
+++ b/pytrainer/totalgraph.py
@@ -38,7 +38,7 @@ class TotalGraph(TimeGraph):
     def getYears(self, yvalues):
         years = set()
         for s in yvalues.values():
-            years |= set([str(x) for x in xrange(int(min(s.keys())), int(max(s.keys()))+1)])
+            years |= set([str(x) for x in range(int(min(s.keys())), int(max(s.keys()))+1)])
         return sorted(list(years))
 
     def drawgraph(self,values):

--- a/pytrainer/waypoint.py
+++ b/pytrainer/waypoint.py
@@ -85,7 +85,7 @@ class WaypointService(object):
 
     def actualize_fromgpx(self,gpxfile):
         logging.debug(">>")
-        from lib.gpx import Gpx
+        from .lib.gpx import Gpx
         gpx = Gpx(self.data_path,gpxfile)
         tracks = gpx.getTrackRoutes()
 
@@ -95,7 +95,7 @@ class WaypointService(object):
             self._actualize_fromgpx(gpx)
         else:
             msg = _("The gpx file seems to be a several days records. Perhaps you will need to edit your gpx file")
-            from gui.warning import Warning
+            from .gui.warning import Warning
             warning = Warning(self.data_path,self._actualize_fromgpx,[gpx])
             warning.set_text(msg)
             warning.run()

--- a/pytrainer/weekgraph.py
+++ b/pytrainer/weekgraph.py
@@ -42,4 +42,3 @@ class WeekGraph(TimeGraph):
 def getDays(date_ini):
 	#TODO look at using calendar.day_abbr for this
 	return [locale_str((date_ini+datetime.timedelta(x)).strftime("%a")) for x in range(0,7)]
-

--- a/pytrainer/yeargraph.py
+++ b/pytrainer/yeargraph.py
@@ -38,7 +38,7 @@ class YearGraph(TimeGraph):
         self.KEY_FORMAT = "%m"
 
     def drawgraph(self,values):
-        TimeGraph.drawgraph(self, values, x_func=lambda x: ["%02d" % m for m in xrange(1,13)])
+        TimeGraph.drawgraph(self, values, x_func=lambda x: ["%02d" % m for m in range(1,13)])
 
     def drawgraph2(self,values):
         


### PR DESCRIPTION
This should fix most of the issues preventing pytrainer from working equally under Python 2 and Python 3. Issues may remain in plugins and other less commonly used code.

It is expected that eventually Python 2 support will be deprecated.