### PR TITLE
Fix Unicode problem in lap comment editing

### DIFF
--- a/pytrainer/gui/windowmain.py
+++ b/pytrainer/gui/windowmain.py
@@ -503,7 +503,7 @@ class Main(SimpleBuilderApp):
 
                 def edited_cb(cell, path, new_text, (liststore, activity)):
                     liststore[path][12] = new_text
-                    activity.Laps[int(path)].comments = new_text
+                    activity.Laps[int(path)].comments = gtk_str(new_text)
                     self.pytrainer_main.ddbb.session.commit()
 
                 def show_tooltip(widget, x, y, keyboard_mode, tooltip, user_param1):


### PR DESCRIPTION
Lap comments can be edited in a different way than other fields, this can't
be found by grepping for get_text and was missed in b2401aaf5664.

Thanks to Håkan Jerning for reporting the bug.