### PR TITLE
Remove WindowMain.addImportPlugin and warn if trying to use it

### DIFF
--- a/pytrainer/gui/windowmain.py
+++ b/pytrainer/gui/windowmain.py
@@ -236,13 +236,6 @@ class Main(SimpleBuilderApp):
                 logging.debug("Removing extension: %s ", extension[0])
                 self.recordbuttons_hbox.remove(widget)
 
-    def addImportPlugin(self,plugin):
-        button = Gtk.MenuItem(plugin[0])
-        button.set_name(plugin[1])
-        button.connect("activate", self.parent.runPlugin, plugin[1])
-        self.menuitem1_menu.insert(button,3)
-        self.menuitem1_menu.show_all()
-
     def addExtension(self,extension):
         #txtbutton,extensioncode,extensiontype = extension
         button = Gtk.Button(extension[0])

--- a/pytrainer/main.py
+++ b/pytrainer/main.py
@@ -197,8 +197,8 @@ class pyTrainer:
                 # Only showing garmintools_full and garmin-hr in 'File' dropdown
                 plugin_name = os.path.basename(plugin)
                 if (plugin_name == "garmintools_full" or plugin_name == "garmin-hr"):
-                    txtbutton = self.plugins.loadPlugin(plugin)
-                    self.windowmain.addImportPlugin(txtbutton)
+                    warnings.warn('Attempted to enable an unsupported plugin %s' % plugin_name,
+                                  UserWarning)
                 else:
                     logging.debug('From version 1.10 on, file import plugins are managed via File -> Import. Not displaying plugin ' + plugin_name)
         logging.debug('<<')
@@ -426,8 +426,8 @@ class pyTrainer:
                 #new active plugin -> need to load plugin
                 plugin_name = os.path.basename(plugin)
                 if (plugin_name == "garmintools_full" or plugin_name == "garmin-hr"):
-                    txtbutton = self.plugins.loadPlugin(plugin)
-                    self.windowmain.addImportPlugin(txtbutton)
+                    warnings.warn('Attempted to enable an unsupported plugin %s' % plugin_name,
+                                  UserWarning)
                 else:
                     logging.debug('From version 1.10 on file import plugins are managed via File -> Import. Not displaying plugin ' + plugin_name)
         logging.debug('<<')


### PR DESCRIPTION
This cannot be supported as is using GTK 3. Perhaps these plugins need to
be ported to work the same way as all the others do, or perhaps this
functionality needs to be implemented differently.