### PR TITLE
Migrate commands, os.popen, os.system to subprocess

### DIFF
--- a/extensions/wordpress/wordpress.py
+++ b/extensions/wordpress/wordpress.py
@@ -159,7 +159,13 @@ class wordpress:
             #htmlpath = googlemaps.drawMap(self.gpxfile,self.googlekey,htmlpath)    #TODO fix to use main googlemaps and remove extensions copy
             htmlpath = self.googlemaps.drawMap(self.activity)
             #create the kml file
-            os.system("gpsbabel -t -i gpx -f %s -o kml,points=0,line_color=ff0000ff -F %s" %(self.gpxfile,kmlpath)) #TODO fix to remove gpsbabel
+            #TODO fix to remove gpsbabel
+            subprocess.call(["gpsbabel",
+                             "-t",
+                             "-i", "gpx",
+                             "-f", self.gpxfile,
+                             "-o", "kml,points=0,line_color=ff0000ff",
+                             "-F", kmlpath])
 
             #gfile = self.wp.newMediaObject(self.gpxfile)
             gfile = self.wp.newMediaObject(gpxpath)

--- a/imports/tool_gant.py
+++ b/imports/tool_gant.py
@@ -18,7 +18,7 @@
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 import logging
-import os, sys, commands
+import os, sys, subprocess
 from lxml import etree
 
 class gant():
@@ -33,9 +33,12 @@ class gant():
 		return _("Gant")
 
 	def getVersion(self):
-		outstatus = commands.getstatusoutput('which gant')
-		if outstatus[0] == 0: #Found gant in path 
-			path = outstatus[1]
+		process = subprocess.Popen(['which', 'gant'],
+		                           stdout=subprocess.PIPE,
+		                           stderr=subprocess.PIPE)
+		stdout, stderr = process.communicate()
+		if process.returncode == 0: # Found gant in path
+			path = stdout[:-1] # remove trailing newline
 			return path
 		else:
 			return None
@@ -48,7 +51,4 @@ class gant():
 		return True
 
 	def isPresent(self):
-		if self.getVersion():
-			return True
-		else:
-			return False
+		return self.getVersion() is not None

--- a/imports/tool_garmintools.py
+++ b/imports/tool_garmintools.py
@@ -18,7 +18,7 @@
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 import logging
-import os, sys, commands
+import os, sys, subprocess
 from lxml import etree
 
 class garmintools():
@@ -33,9 +33,12 @@ class garmintools():
 		return _("Garmintools")
 
 	def getVersion(self):
-		outstatus = commands.getstatusoutput('which garmin_save_runs')
-		if outstatus[0] == 0: #Found garmin_save_runs in path 
-			path = "Unknown"
+		process = subprocess.Popen(['which', 'garmin_save_runs'],
+		                           stdout=subprocess.PIPE,
+		                           stderr=subprocess.PIPE)
+		stdout, stderr = process.communicate()
+		if process.returncode == 0: # Found garmin_save_runs in path
+		        path = stdout[:-1] # remove trailing newline
 			return path
 		else:
 			return None
@@ -44,14 +47,16 @@ class garmintools():
 		return "http://code.google.com/p/garmintools/"
 
 	def deviceExists(self):
-		outstatus = commands.getstatusoutput('garmin_get_info')
-		if outstatus[0] is not 0 or outstatus[1].startswith("garmin unit could not be opened"):
+		process = subprocess.Popen('garmin_get_info',
+		                           stdout=subprocess.PIPE,
+		                           stderr=subprocess.PIPE)
+		stdout, stderr = process.communicate()
+		if (process.returncode is not 0
+		    or
+		    stdout.startswith("garmin unit could not be opened")):
 			return False
 		else:
 			return True
 
 	def isPresent(self):
-		if self.getVersion():
-			return True
-		else:
-			return False
+		return self.getVersion() is not None

--- a/imports/tool_gpsbabel.py
+++ b/imports/tool_gpsbabel.py
@@ -18,7 +18,7 @@
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 import logging
-import os, sys, commands
+import os, sys, subprocess
 from lxml import etree
 
 class gpsbabel():
@@ -33,9 +33,12 @@ class gpsbabel():
 		return _("GPSBabel")
 
 	def getVersion(self):
-		result = commands.getstatusoutput('gpsbabel -V')
-		if result[0] == 0:
-			version = result[1].split()
+		process = subprocess.Popen(['gpsbabel', '-V'],
+		                           stdout=subprocess.PIPE,
+		                           stderr=subprocess.PIPE)
+		stdout, stderr = process.communicate()
+		if process.returncode == 0:
+			version = stdout.split()
 			try:
 				return version[2]
 			except:
@@ -48,17 +51,15 @@ class gpsbabel():
 
 	def deviceExists(self):
 		try:
-			#TODO Check if this is correct???
-			outmod = commands.getstatusoutput('/sbin/lsmod | grep garmin_gps')
-			if outmod[0]==256:	#there is no garmin_gps module loaded
-				return False
-			else:
-				return True
+			process = subprocess.Popen('lsmod | grep garmin_gps',
+			                           stdout=subprocess.PIPE,
+			                           stderr=subprocess.PIPE,
+			                           shell=True)
+			stdout, stderr = process.communicate()
+			# stdout is empty if no garmin_gps module loaded
+			return stdout != ''
 		except:
 			return False
 
 	def isPresent(self):
-		if self.getVersion():
-			return True
-		else:
-			return False
+		return self.getVersion() is not None

--- a/plugins/googleearth/main.py
+++ b/plugins/googleearth/main.py
@@ -19,7 +19,7 @@
 
 
 import os
-import commands
+import subprocess
 import logging
 from lxml import etree
 from pytrainer.gui.dialogs import fileChooserDialog, guiFlush
@@ -44,7 +44,13 @@ class googleearth():
 				if not self.inDatabase(filename):
 					sport = self.getSport(filename) #TODO Fix sport determination
 					gpxfile = "%s/googleearth-%d.gpx" % (self.tmpdir, len(importfiles))
-					outgps = commands.getstatusoutput("gpsbabel -t -i kml -f %s -o gpx -F %s" % (filename, gpxfile) )
+					outgps = subprocess.call(
+					            ["gpsbabel",
+					             "-t",
+					             "-i", "kml",
+					             "-f", filename,
+					             "-o", "gpx",
+					             "-F", gpxfile])
 					#self.createGPXfile(gpxfile, filename) #TODO Fix processing so not dependant on the broken gpsbabel
 					importfiles.append((gpxfile, sport))
 				else:


### PR DESCRIPTION
Migrate every call to use subprocess, different approaches depending on
what is needed: return code, stdout, proper shell.

Unrelated changes:

* Move hardcoded zenity calls to msg_dialog method in garmin-hr plugin

* Return absolute path for garmintools instead of "Unknown"

* Minor cleanup in import/tool_*.py isPresent() method

Fixes: #18