### PR TITLE
Avoid divide by zero in analytics if record discance is 0

### DIFF
--- a/pytrainer/gui/windowmain.py
+++ b/pytrainer/gui/windowmain.py
@@ -805,7 +805,11 @@ class Main(SimpleBuilderApp):
         record_list = activity.tracks
 
         def project(d,a):
-            return int(a.duration * (d / a.distance)**1.06)
+            # avoid divide by zero if distance is 0
+            try:
+                return int(a.duration * (d / a.distance)**1.06)
+            except ZeroDivisionError:
+                return 0
 
         DISTANCES = {
             .8    : _("800 m"),


### PR DESCRIPTION
If the record distance is 0 (zero) then a divide by zero occurs when viewing
the analytics tab.

```
Traceback (most recent call last):
  File "/home/avtobiff/src/github/avtobiff/pytrainer/pytrainer/gui/windowmain.py", line 1678, in on_recordpage_change
    self.parent.refreshRecordGraphView(selected_view)
  File "/home/avtobiff/src/github/avtobiff/pytrainer/pytrainer/main.py", line 334, in refreshRecordGraphView
    self.windowmain.actualize_analytics(activity)
  File "/home/avtobiff/src/github/avtobiff/pytrainer/pytrainer/gui/windowmain.py", line 836, in actualize_analytics
    3, str(project(d, activity)),
  File "/home/avtobiff/src/github/avtobiff/pytrainer/pytrainer/gui/windowmain.py", line 808, in project
    return int(a.duration * (d / a.distance)**1.06)
ZeroDivisionError: float division by zero
