### PR TITLE
Save GPX file with datetime instead of just record id

### DIFF
--- a/pytrainer/record.py
+++ b/pytrainer/record.py
@@ -159,10 +159,10 @@ class Record:
         self.pytrainer_main.ddbb.session.commit()
         if os.path.isfile(gpxOrig):
             gpxDest = self.pytrainer_main.profile.gpxdir
-            gpxNew = gpxDest+"/%d.gpx" % record.id
-            #Leave original file in place...
-            #shutil.move(gpxOrig, gpxNew)
-            #logging.debug('Moving '+gpxOrig+' to '+gpxNew)
+            gpxNew = "{}/{}-{}.gpx".format(
+                                       gpxDest,
+                                       record.date_time_local.replace(" ", "-"),
+                                       record.id)
             shutil.copy(gpxOrig, gpxNew)
             logging.debug('Copying %s to %s', gpxOrig, gpxNew)
         logging.debug('<<')


### PR DESCRIPTION
Before GPX files for records were saved with the filename record's id
with ".gpx" appended. With this change the GPX file is saved as the
record's local datetime, id, and appended with ".gpx" file suffix.

Fixes: #48