### PR TITLE
Fix invalid selected last day of month

### DIFF
--- a/pytrainer/lib/date.py
+++ b/pytrainer/lib/date.py
@@ -88,7 +88,15 @@ class Date:
         #hack for the gtk calendar widget
         if self.calendar is not None:
             year,month,day = self.calendar.get_date()
-            return datetime.date(year, month+1, day)
+            # Selected day might be larger than current month's number of days.
+            # Iterate backwards until we find valid date.
+            while day > 1:
+                try:
+                    return datetime.date(year, month + 1, day)
+                except ValueError:
+                    day -= 1
+            raise ValueError("Invalid date supplied: "
+                             "day is before 1st of month.")
         else:
             return datetime.date.today()
 

--- a/pytrainer/test/lib/test_date.py
+++ b/pytrainer/test/lib/test_date.py
@@ -19,7 +19,7 @@ import datetime
 from mock import Mock
 from dateutil.tz import tzutc, tzlocal
 from pytrainer.lib.date import second2time, time2second, time2string, unixtime2date, getNameMonth, getDateTime
-from pytrainer.lib.date import DateRange
+from pytrainer.lib.date import Date, DateRange
 
 class DateFunctionTest(unittest.TestCase):
 
@@ -48,6 +48,24 @@ class DateFunctionTest(unittest.TestCase):
         utctime, localtime = getDateTime('Tue Nov 24 17:29:05 UTC 2015')
         self.assertEqual(datetime.datetime(2015, 11, 24, 17, 29, 5, tzinfo=tzutc()), utctime)
         self.assertEqual(datetime.datetime(2015, 11, 24, 19, 29, 5, tzinfo=tzlocal()), localtime)
+
+
+class DateTest(unittest.TestCase):
+
+    def test_getDate_should_return_valid_date_if_day_is_too_large(self):
+        mock_calendar = Mock()
+        attrs = {'get_date.return_value': (2019, 1, 31)} # 2019-02-31
+        mock_calendar.configure_mock(**attrs)
+        self.assertEqual(datetime.date(2019,2,28),
+                         Date(mock_calendar).getDate())
+
+    def test_getDate_should_raise_ValueError_if_day_is_before_first(self):
+        mock_calendar = Mock()
+        attrs = {'get_date.return_value': (2019, 1, 0)} # 2019-02-00
+        mock_calendar.configure_mock(**attrs)
+        with self.assertRaises(ValueError):
+            Date(mock_calendar).getDate()
+
 
 class DateRangeTest(unittest.TestCase):
 


### PR DESCRIPTION
If last day of month is selected, it might be larger than the current
month's number of days. Iterate backwards until we find a valid date.

Reproduce by selecting last day of a month with more days (e.g. January 31st)
then change month (e.g. February), the folliwing crash occurs:
```
Traceback (most recent call last):
  File "/home/avtobiff/src/github/avtobiff/pytrainer/pytrainer/gui/windowmain.py", line 1673, in on_page_change
    self.parent.refreshGraphView(self.selected_view)
  File "/home/avtobiff/src/github/avtobiff/pytrainer/pytrainer/main.py", line 263, in refreshGraphView
    date_selected = self.date.getDate()
  File "/home/avtobiff/src/github/avtobiff/pytrainer/pytrainer/lib/date.py", line 91, in getDate
    return datetime.date(year, month+1, day)
ValueError: day is out of range for month
Traceback (most recent call last):
  File "/home/avtobiff/src/github/avtobiff/pytrainer/pytrainer/gui/windowmain.py", line 1739, in on_calendar_changemonth
    self.parent.refreshListRecords()
  File "/home/avtobiff/src/github/avtobiff/pytrainer/pytrainer/main.py", line 353, in refreshListRecords
    date = self.date.getDate()
  File "/home/avtobiff/src/github/avtobiff/pytrainer/pytrainer/lib/date.py", line 91, in getDate
    return datetime.date(year, month+1, day)
ValueError: day is out of range for month
