### PR TITLE
Work around issues with mock 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,14 @@ addons:
       - python-matplotlib
       - python-tornado
       - python-cairo
+      - python-mock
       - python3-setuptools
       - python3-gi
       - python3-lxml
       - python3-cairo
       - python3-gi-cairo
       - python3-matplotlib
+      - python3-mock
 services:
   - mysql
 env:

--- a/pytrainer/test/core/test_activity.py
+++ b/pytrainer/test/core/test_activity.py
@@ -16,7 +16,10 @@
 
 import unittest
 import datetime
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from dateutil.tz import tzoffset
 from sqlalchemy.orm.exc import NoResultFound
 

--- a/pytrainer/test/gui/test_equipment.py
+++ b/pytrainer/test/gui/test_equipment.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from pytrainer.core.equipment import Equipment, EquipmentService
 from pytrainer.gui.equipment import EquipmentStore, EquipmentUi
 from pytrainer.lib.ddbb import DDBB

--- a/pytrainer/test/lib/test_date.py
+++ b/pytrainer/test/lib/test_date.py
@@ -16,7 +16,10 @@
 
 import unittest
 import datetime
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from dateutil.tz import tzutc, tzlocal
 from pytrainer.lib.date import second2time, time2second, time2string, unixtime2date, getNameMonth, getDateTime
 from pytrainer.lib.date import Date, DateRange

--- a/pytrainer/test/lib/test_uc.py
+++ b/pytrainer/test/lib/test_uc.py
@@ -16,7 +16,10 @@
 
 import unittest
 from datetime import date
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from pytrainer.lib.uc import *
 

--- a/pytrainer/test/test_athlete.py
+++ b/pytrainer/test/test_athlete.py
@@ -16,7 +16,10 @@
 
 import unittest
 from datetime import date
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from pytrainer.lib.ddbb import DDBB
 from pytrainer.profile import Profile

--- a/pytrainer/test/test_environment.py
+++ b/pytrainer/test/test_environment.py
@@ -18,7 +18,10 @@
 
 import unittest
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from pytrainer.environment import Environment
 

--- a/pytrainer/test/test_waypoint.py
+++ b/pytrainer/test/test_waypoint.py
@@ -16,7 +16,10 @@
 
 import unittest
 from datetime import date
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from pytrainer.lib.ddbb import DDBB
 from pytrainer.waypoint import WaypointService

--- a/pytrainer/test/upgrade/test_data.py
+++ b/pytrainer/test/upgrade/test_data.py
@@ -17,7 +17,10 @@
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 import unittest
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from pytrainer.upgrade.data import InstalledData, DataState, DataInitializationException
 import pytrainer.upgrade.context
 


### PR DESCRIPTION
The latest versions of mock no longer install on Python 3 versions that have a built-in version. Work around that.