### PR TITLE
Use cgi.escape instead of html.escape when running under Python 2

### DIFF
--- a/pytrainer/extensions/googlemaps.py
+++ b/pytrainer/extensions/googlemaps.py
@@ -18,11 +18,15 @@
 
 import os
 import re
-import html
 import logging
 import colorsys
 import math
 import traceback
+
+try:
+    import html
+except ImportError:
+    import cgi as html
 
 import pytrainer.lib.points as Points
 from pytrainer.lib.fileUtils import fileUtils

--- a/pytrainer/extensions/osm.py
+++ b/pytrainer/extensions/osm.py
@@ -5,11 +5,15 @@
 
 import os
 import re
-import html
 import logging
 import requests         # for downloading cached versions of openlayers.js and openstreetmaps.js
 import time             # Used for checking if local cached file is current
-    
+
+try:
+    import html
+except ImportError:
+    import cgi as html
+
 from pytrainer.lib.gpx import Gpx
 import pytrainer.lib.points as Points
 from pytrainer.lib.fileUtils import fileUtils


### PR DESCRIPTION
Fixes #206. Thanks @avtobiff for the quick debugging work.

It must be said that at this point Python 2 support is no longer a high priority, instead fixing issues when running under Python 3 is critical (upstream support for Python 2 is running out).