### PR TITLE
Clean up mock library usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ addons:
       - python3-cairo
       - python3-gi-cairo
       - python3-matplotlib
-      - python3-mock
 services:
   - mysql
 env:

--- a/pytrainer/test/core/test_equipment.py
+++ b/pytrainer/test/core/test_equipment.py
@@ -18,7 +18,6 @@
 
 import unittest
 import sys
-import mock
 from pytrainer.core.equipment import Equipment, EquipmentService,\
     EquipmentServiceException
 from pytrainer.lib.ddbb import DDBB, DeclarativeBase

--- a/pytrainer/test/core/test_sport.py
+++ b/pytrainer/test/core/test_sport.py
@@ -19,7 +19,6 @@
 import unittest
 import sys
 from pytrainer.core.sport import Sport, SportService, SportServiceException
-import mock
 import pytrainer.core
 from pytrainer.lib.ddbb import DDBB
 from sqlalchemy.exc import IntegrityError, StatementError, ProgrammingError, OperationalError, InterfaceError, DataError

--- a/pytrainer/test/imports/test_garminfit.py
+++ b/pytrainer/test/imports/test_garminfit.py
@@ -5,8 +5,11 @@ __copyright__ = "Copyright © 2013 David García Granda"
 __license__ = "GPL v2 or later"
 
 import unittest
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 import os
-import mock
 from lxml import etree
 from imports.file_garminfit import garminfit
 from pytrainer.lib.ddbb import DDBB
@@ -17,8 +20,8 @@ class GarminFitTest(unittest.TestCase):
         self.ddbb = DDBB()
         self.ddbb.connect()
         self.ddbb.create_tables(add_default=True)
-        self.parent = mock.Mock()
-        self.parent.parent = mock.Mock()
+        self.parent = Mock()
+        self.parent.parent = Mock()
         self.parent.parent.ddbb = self.ddbb
 
     def tearDown(self):

--- a/pytrainer/test/imports/test_garmintcxv2.py
+++ b/pytrainer/test/imports/test_garmintcxv2.py
@@ -5,8 +5,11 @@ __copyright__ = "Copyright © 2013 David García Granda"
 __license__ = "GPL v2 or later"
 
 import unittest
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 import os
-import mock
 from lxml import etree
 from imports.file_garmintcxv2 import garmintcxv2
 from pytrainer.lib.ddbb import DDBB
@@ -18,8 +21,8 @@ class GarminTCXv2Test(unittest.TestCase):
         self.ddbb = DDBB()
         self.ddbb.connect()
         self.ddbb.create_tables(add_default=True)
-        self.parent = mock.Mock()
-        self.parent.parent = mock.Mock()
+        self.parent = Mock()
+        self.parent.parent = Mock()
         self.parent.parent.ddbb = self.ddbb
 
     def tearDown(self):

--- a/pytrainer/test/lib/test_listview.py
+++ b/pytrainer/test/lib/test_listview.py
@@ -1,11 +1,14 @@
 import os
 import datetime
-import mock
 
 from sqlalchemy.orm.session import make_transient
 
 from gi.repository import Gtk
 from unittest import TestCase
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from pytrainer.lib.ddbb import DDBB
 from pytrainer.lib.localization import initialize_gettext, gtk_str
 from pytrainer.core.sport import SportService
@@ -41,7 +44,7 @@ class ListviewTest(TestCase):
         env = Environment()
         env.data_path = os.curdir
         env.create_directories()
-        self.main = mock.Mock()
+        self.main = Mock()
         self.main.ddbb = DDBB()
         self.main.ddbb.connect()
         self.main.ddbb.create_tables()

--- a/pytrainer/test/plugins/test_garmin-tcxv2.py
+++ b/pytrainer/test/plugins/test_garmin-tcxv2.py
@@ -1,6 +1,9 @@
 import unittest
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 import os
-import mock
 from lxml import etree
 
 from pytrainer.plugins import Plugins
@@ -13,10 +16,10 @@ class GarminTCXv2PluginTest(unittest.TestCase):
         self.ddbb = DDBB()
         self.ddbb.connect()
         self.ddbb.create_tables(add_default=True)
-        main = mock.Mock()
+        main = Mock()
         main.ddbb = self.ddbb
-        main.startup_options = mock.Mock()
-        main.profile = mock.Mock()
+        main.startup_options = Mock()
+        main.profile = Mock()
         main.profile.plugindir = 'plugins'
         plugins = Plugins(parent=main)
         self.plugin = plugins.importClass('plugins/garmin-tcxv2')

--- a/pytrainer/test/test_record.py
+++ b/pytrainer/test/test_record.py
@@ -15,7 +15,10 @@
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 import unittest
-import mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from datetime import datetime, date
 from dateutil.tz import tzoffset
 from pytrainer.lib.ddbb import DDBB
@@ -29,7 +32,7 @@ class RecordTest(unittest.TestCase):
         self.ddbb = DDBB()
         self.ddbb.connect()
         self.ddbb.create_tables(add_default=True)
-        self.main = mock.Mock()
+        self.main = Mock()
         self.main.ddbb = self.ddbb
         self.main.activitypool = ActivityService(pytrainer_main=self.main)
         self.main.profile.gpxdir = '/nonexistent'

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,6 @@ setup( 	name = "pytrainer",
 			'matplotlib',
 			'lxml'],
 	test_suite='pytrainer.test',
-	tests_require=['mock', 'mysqlclient', 'psycopg2'],
+	tests_require=['mysqlclient', 'psycopg2'],
 	zip_safe=False
 )


### PR DESCRIPTION
Clean up some imports and remove the requirement for the separate mock library when running tests on Python 3 (which has mock built in).