### PR TITLE
Fix `SyntaxWarning`s

### DIFF
--- a/imports/tool_garmintools.py
+++ b/imports/tool_garmintools.py
@@ -51,7 +51,7 @@ class garmintools():
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
         stdout, stderr = process.communicate()
-        if (process.returncode is not 0
+        if (process.returncode != 0
             or
             stdout.startswith("garmin unit could not be opened")):
             return False

--- a/pytrainer/gui/drawArea.py
+++ b/pytrainer/gui/drawArea.py
@@ -274,7 +274,7 @@ class DrawArea:
                         height = self.NEARLY_ZERO
                     yheights[index] = height
                     textToAdd = self.fmtTableText(height, valuesAreTime[1])
-                    if textToAdd is not ' ':
+                    if textToAdd != ' ':
                         row = keys.index(key)
                         col = index
                         cellText[row][col] += " | %s" % (self.fmtTableText(height, valuesAreTime[1]))

--- a/pytrainer/lib/listview.py
+++ b/pytrainer/lib/listview.py
@@ -110,7 +110,7 @@ class ListSearch(object):
     
     def setup_lsa_sport(self):
         liststore_lsa =  self.parent.lsa_sport.get_model() 
-        if self.parent.lsa_sport.get_active() is not 0:
+        if self.parent.lsa_sport.get_active() != 0:
             self.parent.lsa_sport.set_active(0) #Set first item active if isnt
         firstEntry = gtk_str(self.parent.lsa_sport.get_active_text())
         liststore_lsa.clear() #Delete all items


### PR DESCRIPTION
Fix a couple of `SyntaxWarning`s, first noticed when doing an `apt upgrade` on Debian:

```
running python rtupdate hooks for python3.11...
/usr/share/pytrainer/imports/tool_garmintools.py:54: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if (process.returncode is not 0
```

This appears to come from [a new warning added in Python 3.8](https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior).

I did a quick search across the code base and found a couple more.