### PR TITLE
Allow testing with tox

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,3 +59,22 @@ jobs:
           TZ: Europe/Kaliningrad
           LC_TIME: C
         run: xvfb-run python3 -Wall setup.py test
+
+  test_tox:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,5 +57,5 @@ jobs:
         env:
           PYTRAINER_ALCHEMYURL: ${{ matrix.database_url }}
           TZ: Europe/Kaliningrad
-          LC_TIME: en_US.UTF-8
+          LC_TIME: C
         run: xvfb-run python3 -Wall setup.py test

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 __pycache__
 .eggs/
 pytrainer.egg-info
+.tox/

--- a/pytrainer/athlete.py
+++ b/pytrainer/athlete.py
@@ -22,7 +22,6 @@ import dateutil
 
 from pytrainer.lib.ddbb import DeclarativeBase, ForcedInteger
 from sqlalchemy import Column, Float, Date, Integer
-from pytrainer.lib.graphdata import GraphData
 from pytrainer.lib.uc import UC
 
 class Athletestat(DeclarativeBase):
@@ -65,6 +64,7 @@ class Athlete:
         return ret
 
     def get_athlete_data(self):
+        from pytrainer.lib.graphdata import GraphData
         logging.debug('>>')
         graphdata = {}
         graphdata['weight'] = GraphData(title="Weight", xlabel="Date", ylabel="Weight (%s)" % (self.uc.unit_weight))

--- a/pytrainer/core/activity.py
+++ b/pytrainer/core/activity.py
@@ -24,7 +24,6 @@ from dateutil.tz import tzlocal
 
 from pytrainer.lib.date import second2time
 from pytrainer.lib.gpx import Gpx
-from pytrainer.lib.graphdata import GraphData
 from pytrainer.environment import Environment
 from pytrainer.lib import uc
 from pytrainer.profile import Profile
@@ -440,6 +439,7 @@ tracks (%s)
         return self.sport.name
 
     def _generate_per_lap_graphs(self):
+        from pytrainer.lib.graphdata import GraphData
         '''Build lap based graphs...'''
         logging.debug(">>")
         if self.laps is None:
@@ -499,6 +499,7 @@ tracks (%s)
         logging.debug("<<")
 
     def _init_graph_data(self):
+        from pytrainer.lib.graphdata import GraphData
         logging.debug(">>")
         if self.tracklist is None:
             logging.debug("No tracklist in activity")

--- a/pytrainer/record.py
+++ b/pytrainer/record.py
@@ -25,8 +25,6 @@ import warnings
 
 from sqlalchemy.orm.exc import NoResultFound
 
-from .gui.windowrecord import WindowRecord
-from .gui.dialogselecttrack import DialogSelectTrack
 from .lib.date import Date, time2second
 from .lib.gpx import Gpx
 from pytrainer.core.equipment import EquipmentService, Equipment
@@ -47,6 +45,7 @@ class Record:
         logging.debug('<<')
 
     def newRecord(self, date, title=None, distance=None, time=None, upositive=None, unegative=None, bpm=None, calories=None, comment=None):
+        from .gui.windowrecord import WindowRecord
         logging.debug('>>')
         sports = self._sport_service.get_all_sports()
         self.recordwindow = WindowRecord(self._equipment_service, self.data_path, sports, self, self.format_date(date), title, distance, time, upositive, unegative, bpm, calories, comment)
@@ -54,6 +53,7 @@ class Record:
         logging.debug('<<')
 
     def newMultiRecord(self, activities):
+        from .gui.windowrecord import WindowRecord
         logging.debug('>>')
         sports = self._sport_service.get_all_sports()
         self.recordwindow = WindowRecord(self._equipment_service, self.data_path, sports, parent=self, windowTitle=_("Modify details before importing"))
@@ -62,7 +62,8 @@ class Record:
         return self.recordwindow.getActivityData()
         logging.debug('<<')
 
-    def editRecord(self,id_record):
+    def editRecord(self, id_record):
+        from .gui.windowrecord import WindowRecord
         logging.debug('>>')
         activity = self.pytrainer_main.activitypool.get_activity(id_record)
         sports = self._sport_service.get_all_sports()
@@ -432,6 +433,7 @@ class Record:
         logging.debug('<<')
 
     def _select_trkfromgpx(self,gpxfile,tracks):  #TODO remove? - should never have multiple tracks per GPX file
+        from .gui.dialogselecttrack import DialogSelectTrack
         logging.debug('>>')
         logging.debug('Track dialog %s|%s', self.data_path, gpxfile)
         selectrckdialog = DialogSelectTrack(self.data_path, tracks,self.__actualize_fromgpx, gpxfile)

--- a/pytrainer/test/core/test_activity.py
+++ b/pytrainer/test/core/test_activity.py
@@ -95,7 +95,7 @@ class ActivityTest(unittest.TestCase):
         self.assertEqual(self.activity.time, self.activity.duration)
 
     def test_activity_starttime(self):
-        self.assertEqual(self.activity.starttime, '12:58:23 PM')
+        self.assertEqual(self.activity.starttime, '12:58:23')
 
     def test_activity_time_tuple(self):
         self.assertEqual(self.activity.time_tuple, (2, 3, 46))

--- a/pytrainer/test/gui/test_color.py
+++ b/pytrainer/test/gui/test_color.py
@@ -16,23 +16,30 @@
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-from pytrainer.gui.color import ColorConverter
-from pytrainer.util.color import Color
-from gi.repository import Gdk
 import unittest
 
+try:
+    from gi.repository import Gdk
+    GDK_AVAILABLE = True
+except ImportError:
+    GDK_AVAILABLE = False
+
+
+@unittest.skipUnless(GDK_AVAILABLE, 'GDK library not available')
 class ColorConverterTest(unittest.TestCase):
-    
+
     def setUp(self):
+        from pytrainer.gui.color import ColorConverter
         self._converter = ColorConverter()
-    
+
     def test_convert_to_gdk_color_should_create_gdk_color_with_equivalent_rgb_values(self):
+        from pytrainer.util.color import Color
         color = Color(0xaaff33)
         gdk_color = self._converter.convert_to_gdk_color(color)
         self.assertEqual(0x3333, gdk_color.blue)
         self.assertEqual(0xffff, gdk_color.green)
         self.assertEqual(0xaaaa, gdk_color.red)
-        
+
     def test_convert_to_color_should_create_color_with_equivalent_rgb_values(self):
         gdk_col = Gdk.color_parse("#aaff33")
         color = self._converter.convert_to_color(gdk_col)

--- a/pytrainer/test/gui/test_equipment.py
+++ b/pytrainer/test/gui/test_equipment.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from mock import Mock
 from pytrainer.core.equipment import Equipment, EquipmentService
-from pytrainer.gui.equipment import EquipmentStore, EquipmentUi
+from pytrainer.gui.equipment import EquipmentUi
 from pytrainer.lib.ddbb import DDBB
 from pytrainer.lib.localization import initialize_gettext
 
@@ -27,19 +27,20 @@ from pytrainer.lib.localization import initialize_gettext
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 class EquipmentStoreTest(TestCase):
-    
+
+    def get_equipment_store(self):
+        from pytrainer.gui.equipment import EquipmentStore
+        return EquipmentStore(self.mock_equipment_service)
+
     def setUp(self):
         self.mock_equipment_service = Mock(spec=EquipmentService)
         self.mock_equipment_service.get_equipment_usage.return_value = 0
-    
-    def tearDown(self):
-        pass
-        
+
     def test_get_item_id(self):
         equipment = Equipment()
         equipment.id = 1
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         self.assertEqual(1, equipment_store.get_value(iter, 0))
         
@@ -48,7 +49,7 @@ class EquipmentStoreTest(TestCase):
         equipment.id = 1
         equipment.description = u"item description"
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         self.assertEqual("item description", equipment_store.get_value(iter, 1))
         
@@ -58,7 +59,7 @@ class EquipmentStoreTest(TestCase):
         equipment.life_expectancy = 200
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
         self.mock_equipment_service.get_equipment_usage.return_value = 100
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         self.assertEqual(50, equipment_store.get_value(iter, 2))
         
@@ -69,7 +70,7 @@ class EquipmentStoreTest(TestCase):
         equipment.prior_usage = 50
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
         self.mock_equipment_service.get_equipment_usage.return_value = 100
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         self.assertEqual(75, equipment_store.get_value(iter, 2))
         
@@ -79,7 +80,7 @@ class EquipmentStoreTest(TestCase):
         equipment.life_expectancy = 200
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
         self.mock_equipment_service.get_equipment_usage.return_value = 0
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         self.assertEqual(0, equipment_store.get_value(iter, 2))
         
@@ -89,7 +90,7 @@ class EquipmentStoreTest(TestCase):
         equipment.life_expectancy = 200
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
         self.mock_equipment_service.get_equipment_usage.return_value = 300
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         self.assertEqual(100, equipment_store.get_value(iter, 2), "Progress bar cannot exceed 100%.")
         
@@ -100,7 +101,7 @@ class EquipmentStoreTest(TestCase):
         equipment.life_expectancy = 200
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
         self.mock_equipment_service.get_equipment_usage.return_value = 100
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         self.assertEqual("100 / 200", equipment_store.get_value(iter, 3))
         
@@ -110,7 +111,7 @@ class EquipmentStoreTest(TestCase):
         equipment.life_expectancy = 200
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
         self.mock_equipment_service.get_equipment_usage.return_value = 100.6
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         self.assertEqual("101 / 200", equipment_store.get_value(iter, 3))
         
@@ -121,7 +122,7 @@ class EquipmentStoreTest(TestCase):
         equipment.prior_usage = 50
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
         self.mock_equipment_service.get_equipment_usage.return_value = 100
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         self.assertEqual("150 / 200", equipment_store.get_value(iter, 3))
         
@@ -131,7 +132,7 @@ class EquipmentStoreTest(TestCase):
         equipment.life_expectancy = 200
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
         self.mock_equipment_service.get_equipment_usage.return_value = 0
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         self.assertEqual("0 / 200", equipment_store.get_value(iter, 3))
         
@@ -141,7 +142,7 @@ class EquipmentStoreTest(TestCase):
         equipment.life_expectancy = 200
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
         self.mock_equipment_service.get_equipment_usage.return_value = 300
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         self.assertEqual("300 / 200", equipment_store.get_value(iter, 3))
         
@@ -150,7 +151,7 @@ class EquipmentStoreTest(TestCase):
         equipment.id = 1
         equipment.active = False
         self.mock_equipment_service.get_all_equipment.return_value = [equipment]
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         self.assertFalse(equipment_store.get_value(iter, 4))
     
@@ -160,7 +161,7 @@ class EquipmentStoreTest(TestCase):
         equipment2 = Equipment()
         equipment2.id = 2
         self.mock_equipment_service.get_all_equipment.return_value = [equipment1, equipment2]
-        equipment_store = EquipmentStore(self.mock_equipment_service)
+        equipment_store = self.get_equipment_store()
         iter = equipment_store.get_iter_first()
         iter = equipment_store.iter_next(iter)
         self.assertEqual(2, equipment_store.get_value(iter, 0))

--- a/pytrainer/test/gui/test_equipment.py
+++ b/pytrainer/test/gui/test_equipment.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
-from unittest import TestCase
+import unittest
 try:
     from unittest.mock import Mock
 except ImportError:
     from mock import Mock
+
+try:
+    from gi.repository import Gtk
+    GTK_AVAILABLE = True
+except ImportError:
+    GTK_AVAILABLE = False
+
 from pytrainer.core.equipment import Equipment, EquipmentService
-from pytrainer.gui.equipment import EquipmentUi
 from pytrainer.lib.ddbb import DDBB
 from pytrainer.lib.localization import initialize_gettext
 
@@ -26,7 +32,9 @@ from pytrainer.lib.localization import initialize_gettext
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-class EquipmentStoreTest(TestCase):
+
+@unittest.skipUnless(GTK_AVAILABLE, 'GTK library not available')
+class EquipmentStoreTest(unittest.TestCase):
 
     def get_equipment_store(self):
         from pytrainer.gui.equipment import EquipmentStore
@@ -165,10 +173,13 @@ class EquipmentStoreTest(TestCase):
         iter = equipment_store.get_iter_first()
         iter = equipment_store.iter_next(iter)
         self.assertEqual(2, equipment_store.get_value(iter, 0))
-        
-class EquipmentUiTest(TestCase):
+
+
+@unittest.skipUnless(GTK_AVAILABLE, 'GTK library not available')
+class EquipmentUiTest(unittest.TestCase):
 
     def setUp(self):
+        from pytrainer.gui.equipment import EquipmentUi
         initialize_gettext('locale/')
         self.ddbb = DDBB()
         self.ddbb.connect()

--- a/pytrainer/test/lib/test_ddbb.py
+++ b/pytrainer/test/lib/test_ddbb.py
@@ -23,7 +23,14 @@ try:
 except ImportError:
     import mock
 
+try:
+    import MySQLdb
+    MYSQL_AVAILABLE = True
+except ImportError:
+    MYSQL_AVAILABLE = False
+
 from pytrainer.lib.ddbb import DDBB
+
 
 class DDBBTest(unittest.TestCase):
 
@@ -44,6 +51,7 @@ class DDBBTest(unittest.TestCase):
         self.ddbb = DDBB(url='sqlite:///test_url')
         self.assertEqual(self.ddbb.url, 'sqlite:///test_url')
 
+    @unittest.skipUnless(MYSQL_AVAILABLE, 'MySQLdb library not available')
     def test_mysql_url(self):
         self.ddbb = DDBB(url='mysql://pytrainer@localhost/pytrainer')
         self.assertEqual(self.ddbb.url, 'mysql://pytrainer@localhost/pytrainer?charset=utf8')
@@ -54,6 +62,7 @@ class DDBBTest(unittest.TestCase):
         self.assertEqual(self.ddbb.url, 'sqlite:///envtest')
 
     @mock.patch.dict('os.environ', {'PYTRAINER_ALCHEMYURL': 'mysql://pytrainer@localhost/pytrainer'})
+    @unittest.skipUnless(MYSQL_AVAILABLE, 'MySQLdb library not available')
     def test_env_mysql_url(self):
         self.ddbb = DDBB()
         self.assertEqual(self.ddbb.url, 'mysql://pytrainer@localhost/pytrainer?charset=utf8')

--- a/pytrainer/test/lib/test_listview.py
+++ b/pytrainer/test/lib/test_listview.py
@@ -3,7 +3,6 @@ import datetime
 
 from sqlalchemy.orm.session import make_transient
 
-from gi.repository import Gtk
 from unittest import TestCase
 try:
     from unittest.mock import Mock

--- a/pytrainer/test/lib/test_listview.py
+++ b/pytrainer/test/lib/test_listview.py
@@ -3,7 +3,7 @@ import datetime
 
 from sqlalchemy.orm.session import make_transient
 
-from unittest import TestCase
+import unittest
 try:
     from unittest.mock import Mock
 except ImportError:
@@ -17,8 +17,11 @@ from pytrainer.record import Record
 from pytrainer.core.activity import Activity
 initialize_gettext('locale/')
 
-from pytrainer.gui.windowmain import Main
-from pytrainer.lib.listview import ListSearch
+try:
+    from pytrainer.gui.windowmain import Main
+    GUI_AVAILABLE = True
+except ImportError:
+    GUI_AVAILABLE = False
 from pytrainer.lib.uc import UC
 
 #Copyright (C) Arto Jantunen <viiru@iki.fi>
@@ -37,7 +40,9 @@ from pytrainer.lib.uc import UC
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-class ListviewTest(TestCase):
+
+@unittest.skipUnless(GUI_AVAILABLE, 'Gui libraries not available')
+class ListviewTest(unittest.TestCase):
 
     def setUp(self):
         env = Environment()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py37,py38,py39,py310,py311
+
+[testenv]
+setenv =
+    TZ = Europe/Kaliningrad
+    LC_TIME = C
+    HOME = /tmp
+commands = python3 -m unittest discover


### PR DESCRIPTION
Run most tests (24 tests are skipped due to a lack of libraries in the environment tox builds) against all currently supported versions of Python.