### PR TITLE
Remove Gtk-WARNING on start

### DIFF
--- a/glade/pytrainer.ui
+++ b/glade/pytrainer.ui
@@ -3190,9 +3190,6 @@
                                                     <property name="label" translatable="yes">&lt;b&gt;Projected times&lt;/b&gt;</property>
                                                     <property name="use_markup">True</property>
                                                   </object>
-                                                  <packing>
-                                                    <property name="padding">10</property>
-                                                  </packing>
                                                 </child>
                                               </object>
                                               <packing>
@@ -3448,11 +3445,6 @@
                                           </packing>
                                         </child>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child type="label">
                                       <object class="GtkLabel" id="label14anal">


### PR DESCRIPTION
When starting pytrainer from commandline i got this warnings:

(pytrainer:102240): Gtk-WARNING **: 09:07:16.952: GtkFrame does not have a child property called padding
(pytrainer:102240): Gtk-WARNING **: 09:07:16.954: GtkFrame does not have a child property called expand
(pytrainer:102240): Gtk-WARNING **: 09:07:16.954: GtkFrame does not have a child property called fill
(pytrainer:102240): Gtk-WARNING **: 09:07:16.954: GtkFrame does not have a child property called position

This commit should fix this warnings.
