### PR TITLE
Fix running tests against installed package

### DIFF
--- a/bin/pytrainer
+++ b/bin/pytrainer
@@ -68,7 +68,6 @@ def _get_installation_paths(orig_path):
         and os.path.exists(base_path + "/pytrainer/main.py")
         and os.path.exists(base_path + "/locale")):
         print("running pytrainer from source path")
-        data_path = base_path + "/"
         site_path = base_path
         gettext_path = base_path + "/locale"
     else:
@@ -76,17 +75,15 @@ def _get_installation_paths(orig_path):
         parts = os.path.split(base_path)
         if parts[1] == 'EGG-INFO':
             base_path = parts[0]
-        data_path = base_path + "/share/pytrainer/"
         site_path = "%s/lib/python%s.%s/site-packages" % (base_path, ver[0], ver[1])
         gettext_path = base_path + "/share/locale"
-    return data_path, gettext_path, site_path
+    return gettext_path, site_path
 
 
 # directory that the pytrainer script executes from e.g. /usr/bin or /usr/local/bin
 bin_path = os.path.realpath(os.path.dirname(__file__))
-data_path, gettext_path, site_path = _get_installation_paths(bin_path)
+gettext_path, site_path = _get_installation_paths(bin_path)
 
-print("data_path:", data_path)
 print("gettext_path:", gettext_path)
 print("site_path:", site_path)
 
@@ -98,7 +95,7 @@ def main():
     import pytrainer.lib.localization
     pytrainer.lib.localization.initialize_gettext(gettext_path)
     from pytrainer.main import pyTrainer
-    pytrainer = pyTrainer(None, data_path)
+    pytrainer = pyTrainer()
 
 
 if __name__ == "__main__":

--- a/bin/pytrainer
+++ b/bin/pytrainer
@@ -40,7 +40,6 @@ def _max(one, two):
             return one
         else:
             return two
-    
 
     one_v_nos = one_v.split('.')
     two_v_nos = two_v.split('.')
@@ -59,34 +58,41 @@ def _max(one, two):
     return two
 
 
-bin_path = os.path.realpath(os.path.dirname(__file__)) # directory that the pytrainer script executes from e.g. /usr/bin or /usr/local/bin
-base_path = os.path.dirname(bin_path)
-#Get the version of the running python interpreter
-ver = platform.python_version_tuple()
+def _get_installation_paths(orig_path):
+    base_path = os.path.dirname(bin_path)
+    # Get the version of the running python interpreter
+    ver = platform.python_version_tuple()
 
-if (os.path.exists(base_path + "/INSTALL") 
-    and os.path.exists(base_path + "/setup.py") 
-    and os.path.exists(base_path + "/pytrainer/main.py")
-    and os.path.exists(base_path + "/locale")):
-    print("running pytrainer from source path")
-    data_path = base_path + "/"
-    site_path = base_path
-    gettext_path = base_path + "/locale"
-else:
-    print("running pytrainer from egg installation")
-    parts = os.path.split(base_path)
-    if parts[1] == 'EGG-INFO':
-        base_path = parts[0]
-    data_path = base_path + "/share/pytrainer/"
-    site_path =  "%s/lib/python%s.%s/site-packages" % (base_path, ver[0], ver[1])
-    gettext_path = base_path + "/share/locale"
+    if (os.path.exists(base_path + "/INSTALL")
+        and os.path.exists(base_path + "/setup.py")
+        and os.path.exists(base_path + "/pytrainer/main.py")
+        and os.path.exists(base_path + "/locale")):
+        print("running pytrainer from source path")
+        data_path = base_path + "/"
+        site_path = base_path
+        gettext_path = base_path + "/locale"
+    else:
+        print("running pytrainer from egg installation")
+        parts = os.path.split(base_path)
+        if parts[1] == 'EGG-INFO':
+            base_path = parts[0]
+        data_path = base_path + "/share/pytrainer/"
+        site_path = "%s/lib/python%s.%s/site-packages" % (base_path, ver[0], ver[1])
+        gettext_path = base_path + "/share/locale"
+    return data_path, gettext_path, site_path
 
-print("data_path: " + data_path)
-print("gettext_path: " + gettext_path)
-print("site_path: " + site_path)
 
-#ensure pytrainer directory is included in import path
+# directory that the pytrainer script executes from e.g. /usr/bin or /usr/local/bin
+bin_path = os.path.realpath(os.path.dirname(__file__))
+data_path, gettext_path, site_path = _get_installation_paths(bin_path)
+
+print("data_path:", data_path)
+print("gettext_path:", gettext_path)
+print("site_path:", site_path)
+
+# ensure pytrainer directory is included in import path
 sys.path.insert(0, site_path)
+
 
 def main():
     import pytrainer.lib.localization
@@ -94,6 +100,6 @@ def main():
     from pytrainer.main import pyTrainer
     pytrainer = pyTrainer(None, data_path)
 
-if __name__ == "__main__":
-        main()
 
+if __name__ == "__main__":
+    main()

--- a/pytrainer/gui/equipment.py
+++ b/pytrainer/gui/equipment.py
@@ -16,9 +16,13 @@
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
+import os
+
 from gi.repository import Gtk
 from pytrainer.core.equipment import Equipment
 from pytrainer.lib.localization import gtk_str
+from pytrainer.environment import Environment
+
 
 class EquipmentStore(Gtk.ListStore):
     
@@ -76,13 +80,15 @@ class EquipmentStore(Gtk.ListStore):
         self._equipment_service.remove_equipment(item)
         self.remove(self.get_iter(item_path))
 
+
 class EquipmentUi(Gtk.HBox):
-    
-    def __init__(self, glade_conf_dir, equipment_service):
+
+    def __init__(self, equipment_service):
         super(EquipmentUi, self).__init__()
+        environment = Environment()
         self._equipment_store = EquipmentStore(equipment_service)
         self._builder = Gtk.Builder()
-        self._builder.add_from_file(glade_conf_dir + "/equipment.ui")
+        self._builder.add_from_file(os.path.join(environment.glade_dir, "equipment.ui"))
         self._init_tree_view()
         self._init_signals()
         self.add(self._get_notebook())

--- a/pytrainer/gui/windowprofile.py
+++ b/pytrainer/gui/windowprofile.py
@@ -75,12 +75,12 @@ class WindowProfile(SimpleBuilderApp):
             column.set_resizable(True)
             self.sportTreeView.append_column(column)
 
-        #initialise equipment tab:
+        # initialise equipment tab:
         equipment_service = EquipmentService(self.pytrainer_main.ddbb)
-        equipment_ui = EquipmentUi(self.data_path + "/glade", equipment_service)
-        self.equipment_container.add(equipment_ui) 
-        logging.debug("<<")           
-        
+        equipment_ui = EquipmentUi(equipment_service)
+        self.equipment_container.add(equipment_ui)
+        logging.debug("<<")
+
     def present(self):
         self.newprofile.present()
         

--- a/pytrainer/importdata.py
+++ b/pytrainer/importdata.py
@@ -1,31 +1,32 @@
 # -*- coding: utf-8 -*-
 
-#Copyright (C) Fiz Vazquez vud1@sindominio.net
+# Copyright (C) Fiz Vazquez vud1@sindominio.net
 
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; either version 2
-#of the License, or (at your option) any later version.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
 
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 from .gui.windowimportdata import WindowImportdata
 
+
 class Importdata:
-	def __init__(self, sport_service, data_path = None, parent = None, config = None):
-		self._sport_service = sport_service
-		self.data_path=data_path
-		self.parent = parent
-		self.pytrainer_main = parent
-		self.configuration = config
-	
-	def runImportdata(self):
-		windowImportdata = WindowImportdata(self._sport_service, self.data_path, self, self.configuration, self.pytrainer_main)
-		windowImportdata.run()
+    def __init__(self, sport_service, data_path = None, parent = None, config = None):
+        self._sport_service = sport_service
+        self.data_path=data_path
+        self.parent = parent
+        self.pytrainer_main = parent
+        self.configuration = config
+
+    def runImportdata(self):
+        windowImportdata = WindowImportdata(self._sport_service, self.data_path, self, self.configuration, self.pytrainer_main)
+        windowImportdata.run()

--- a/pytrainer/importdata.py
+++ b/pytrainer/importdata.py
@@ -16,7 +16,31 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-from .gui.windowimportdata import WindowImportdata
+import glob
+import logging
+import os
+import sys
+
+from pytrainer.environment import Environment
+
+
+def import_plugin_class(environment, parent, import_file):
+    directory, filename = os.path.split(import_file)
+    filename = filename.rstrip('.py')
+    logging.debug("Trying: %s", filename)
+    classname = filename.lstrip('file_')
+    # Import module
+    module = __import__(filename)
+    import_class = getattr(module, classname)
+    # Instantiate module
+    return import_class(parent, environment.data_path)
+
+
+def iterate_import_tools(parent):
+    environment = Environment()
+    sys.path.insert(0, os.path.join(environment.data_path, "imports"))
+    for import_file in sorted(glob.iglob(os.path.join(environment.data_path, "imports/file_*.py"))):
+        yield import_plugin_class(environment, parent, import_file)
 
 
 class Importdata:
@@ -28,5 +52,6 @@ class Importdata:
         self.configuration = config
 
     def runImportdata(self):
+        from .gui.windowimportdata import WindowImportdata
         windowImportdata = WindowImportdata(self._sport_service, self.data_path, self, self.configuration, self.pytrainer_main)
         windowImportdata.run()

--- a/pytrainer/main.py
+++ b/pytrainer/main.py
@@ -49,19 +49,20 @@ from .lib.ddbb import DDBB
 from .lib.uc import UC
 
 class pyTrainer:
-    def __init__(self,filename = None, data_path = None):
+
+    def __init__(self):
         # Based on Django's approach -> http://code.djangoproject.com/svn/django/trunk/django/__init__.py
         self.version = __import__('pytrainer').get_version()
         #Process command line options
         self.startup_options = self.get_options()
         #Setup logging
-        self.environment = Environment(self.startup_options.conf_dir, data_path)
+        self.environment = Environment(self.startup_options.conf_dir)
         self.environment.create_directories()
         self.environment.clear_temp_dir()
         self.set_logging(self.startup_options.log_level, self.startup_options.log_type)
         logging.debug('>>')
         logging.info("pytrainer version %s" % (self.version))
-        self.data_path = data_path
+        self.data_path = self.environment.data_path
 
         # Checking profile
         logging.debug('Checking configuration and profile...')
@@ -81,9 +82,9 @@ class pyTrainer:
         logging.debug('Loading sport service...')
         self._sport_service = SportService(self.ddbb)
         logging.debug('Loading record service...')
-        self.record = Record(self._sport_service, data_path, self)
+        self.record = Record(self._sport_service, self.environment.data_path, self)
         logging.debug('Loading athlete service...')
-        self.athlete = Athlete(data_path, self)
+        self.athlete = Athlete(self.environment.data_path, self)
         logging.debug('Loading stats service...')
         self.stats = Stats(self)
         logging.debug('Initializing activity pool...')
@@ -93,18 +94,18 @@ class pyTrainer:
         #Loading main window
         self.windowmain = None
         logging.debug('Loading main window...')
-        self.windowmain = Main(self._sport_service, data_path,self,self.version, gpxDir=self.profile.gpxdir)
+        self.windowmain = Main(self._sport_service, self.environment.data_path, self, self.version, gpxDir=self.profile.gpxdir)
 
         # Select initial date depending on user's preference
         self.selectInitialDate()
         
         logging.debug('Loading waypoint service...')
-        self.waypoint = WaypointService(data_path, self)
+        self.waypoint = WaypointService(self.environment.data_path, self)
         logging.debug('Loading extension service...')
-        self.extension = Extension(data_path, self)
+        self.extension = Extension(self.environment.data_path, self)
         logging.debug('Loading plugins service...')
-        self.plugins = Plugins(data_path, self)
-        self.importdata = Importdata(self._sport_service, data_path, self, self.profile)
+        self.plugins = Plugins(self.environment.data_path, self)
+        self.importdata = Importdata(self._sport_service, self.environment.data_path, self, self.profile)
         logging.debug('Loading plugins...')
         self.loadPlugins()
         logging.debug('Loading extensions...')

--- a/pytrainer/platform.py
+++ b/pytrainer/platform.py
@@ -49,12 +49,24 @@ class _Platform(object):
 """
         return self._first_day_of_week
 
+
 class _Linux(_Platform):
-    
+
+    def _get_data_path(self):
+        base_path = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
+
+        def _checkpath(fname):
+            return os.path.exists(os.path.join(base_path, fname))
+
+        if all(map(_checkpath, ("INSTALL", "setup.py", "pytrainer/main.py", "locale"))):
+            return base_path + "/"
+        else:
+            return os.path.join(sys.prefix, "/share/pytrainer/")
+
     def __init__(self):
         self._home_dir = os.environ['HOME']
         self._conf_dir_name = ".pytrainer"
-        self._data_path = "/usr/share/pytrainer/"
+        self._data_path = self._get_data_path()
         try:
             results = subprocess.check_output(("locale", "first_weekday", "week-1stday"),
                                               universal_newlines=True).splitlines()

--- a/pytrainer/test/gui/test_equipment.py
+++ b/pytrainer/test/gui/test_equipment.py
@@ -185,7 +185,7 @@ class EquipmentUiTest(unittest.TestCase):
         self.ddbb.connect()
         self.ddbb.create_tables()
         self.equipment_service = EquipmentService(self.ddbb)
-        self.equipment_ui = EquipmentUi('glade/', self.equipment_service)
+        self.equipment_ui = EquipmentUi(self.equipment_service)
 
     def tearDown(self):
         self.ddbb.disconnect()

--- a/pytrainer/test/imports/test_garminfit.py
+++ b/pytrainer/test/imports/test_garminfit.py
@@ -10,9 +10,13 @@ try:
 except ImportError:
     from mock import Mock
 import os
+import sys
 from lxml import etree
-from imports.file_garminfit import garminfit
+
+from pytrainer.environment import Environment
 from pytrainer.lib.ddbb import DDBB
+from pytrainer.importdata import import_plugin_class
+
 
 class GarminFitTest(unittest.TestCase):
 
@@ -20,6 +24,7 @@ class GarminFitTest(unittest.TestCase):
         self.ddbb = DDBB()
         self.ddbb.connect()
         self.ddbb.create_tables(add_default=True)
+        self.environment = Environment()
         self.parent = Mock()
         self.parent.parent = Mock()
         self.parent.parent.ddbb = self.ddbb
@@ -31,9 +36,9 @@ class GarminFitTest(unittest.TestCase):
     def test_parse_fit_file(self):
         try:
             current_path = os.path.dirname(os.path.abspath(__file__))
-            data_path = os.path.dirname(os.path.dirname(os.path.dirname(current_path))) + "/"
             fit_file = current_path + "/sample.fit"
-            garmin_fit = garminfit(self.parent, data_path)
+            sys.path.insert(0, os.path.join(self.environment.data_path, "imports"))
+            garmin_fit = import_plugin_class(self.environment, self.parent, "file_garminfit.py")
             xmldoc = etree.fromstring(garmin_fit.fromFIT2TCXv2(fit_file))
             valid_xml = garmin_fit.validate(xmldoc, "schemas/GarminTrainingCenterDatabase_v2.xsd")
             self.assertTrue(valid_xml)

--- a/pytrainer/test/lib/test_listview.py
+++ b/pytrainer/test/lib/test_listview.py
@@ -46,7 +46,6 @@ class ListviewTest(unittest.TestCase):
 
     def setUp(self):
         env = Environment()
-        env.data_path = os.curdir
         env.create_directories()
         self.main = Mock()
         self.main.ddbb = DDBB()

--- a/pytrainer/test/test_platform.py
+++ b/pytrainer/test/test_platform.py
@@ -27,3 +27,6 @@ class PlatformTest(unittest.TestCase):
     def test_first_day_of_week_should_be_less_than_seven(self):
         first_day = get_platform().get_first_day_of_week()
         self.assertTrue(first_day < 7)
+
+    def test_data_path(self):
+        self.assertTrue(get_platform().get_default_data_path().endswith('/'))


### PR DESCRIPTION
* Split the bin/pytrainer installation path finding code to a function
* Move data_path handling from the pytrainer script to Platform
* Have EquipmentUi read the glade path from Environment
* Reindent importdata.py
* Split importing import classes into helper functions
* Use the "usual" import machinery in import tool tests