### PR TITLE
Add support for SQLAlchemy 2+

### DIFF
--- a/plugins/googleearth/main.py
+++ b/plugins/googleearth/main.py
@@ -77,9 +77,6 @@ class googleearth():
 		    only compares date and start time (sport may have been changed in DB after import)
 		"""
 		#time = self.detailsFromKML(filename)
-		#if self.parent.parent.ddbb.select("records","*","date_time_utc=\"%s\"" % (time)):
-		#	return True
-		#else:
 		return False
 
 	def getSport(self, filename):

--- a/pytrainer/core/activity.py
+++ b/pytrainer/core/activity.py
@@ -108,7 +108,9 @@ class ActivityService(object):
         else:
             logging.debug("Activity NOT found in pool")
             self.pool[sid] = self.pytrainer_main.ddbb.session.query(Activity).options(
-                joinedload('sport'), joinedload('equipment'), joinedload('Laps')
+                joinedload(Activity.sport),
+                joinedload(Activity.equipment),
+                joinedload(Activity.Laps)
             ).filter(Activity.id == id).one()
             self.pool_queue.append(sid)
         if len(self.pool_queue) > self.max_size:
@@ -137,9 +139,9 @@ class ActivityService(object):
     def get_activities_for_day(self, date, sport=None):
         """Iterates the activities for a specific date, optionally restricted by Sport)"""
         if not sport:
-            activities = self.pytrainer_main.ddbb.session.query(Activity).filter(Activity.date == date).options(joinedload('Laps'))
+            activities = self.pytrainer_main.ddbb.session.query(Activity).filter(Activity.date == date).options(joinedload(Activity.Laps))
         else:
-            activities = self.pytrainer_main.ddbb.session.query(Activity).filter(and_(Activity.date == date, Activity.sport == sport)).options(joinedload('Laps'))
+            activities = self.pytrainer_main.ddbb.session.query(Activity).filter(and_(Activity.date == date, Activity.sport == sport)).options(joinedload(Activity.Laps))
         for activity in activities:
             sid = str(activity.id)
             if sid in self.pool:

--- a/pytrainer/extensions/googlemaps.py
+++ b/pytrainer/extensions/googlemaps.py
@@ -151,11 +151,6 @@ class Googlemaps:
             documentation at http://code.google.com/apis/maps/documentation/v3
         '''
         logging.debug(">>")
-        if self.waypoint is not None:
-            waypoints = self.waypoint.getAllWaypoints()
-            #TODO waypoints not supported in this function yet
-            #TODO sort polyline encoding (not supported in v3?)
-            #TODO check http://code.google.com/apis/maps/documentation/v3/overlays.html#Polylines for MVArray??
         content = '''
         <html>
         <head>

--- a/pytrainer/lib/ddbb.py
+++ b/pytrainer/lib/ddbb.py
@@ -21,7 +21,6 @@
 
 import logging
 import os
-import warnings
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -86,15 +85,6 @@ if no url is provided"""
 
     def disconnect(self):
         self.session.close()
-
-    def select(self,table,cells,condition=None, mod=None):
-        warnings.warn("Deprecated call to ddbb.select", DeprecationWarning, stacklevel=2)
-        sql = "select %s from %s" %(cells,table)
-        if condition is not None:
-            sql = "%s where %s" % (sql, condition)
-        if mod is not None:
-            sql = "%s %s" % (sql, mod)
-        return list(self.session.execute(sql))
 
     def create_tables(self, add_default=True):
         """Initialise the database schema from an empty database."""

--- a/pytrainer/main.py
+++ b/pytrainer/main.py
@@ -507,7 +507,7 @@ class pyTrainer:
     def exportCsv(self):
         logging.debug('>>')
         from .save import Save
-        save = Save(self.data_path, self.record)
+        save = Save(self.ddbb)
         save.run()
         logging.debug('<<')
 

--- a/pytrainer/record.py
+++ b/pytrainer/record.py
@@ -359,15 +359,6 @@ class Record:
         except NoResultFound:
             return None
 
-    def getAllrecord(self):
-        """
-        Retrieve all record data (no lap nor equipment) stored in database. Initially intended for csv export
-        arguments:
-        returns: list of data sorted by date desc"""
-        logging.debug('--')
-        return self.pytrainer_main.ddbb.select("records,sports", "date_time_local,title,sports.name,distance,duration,average,maxspeed,pace,maxpace,beats,maxbeats,calories,upositive,unegative,comments",
-    "sports.id_sports = records.sport","order by date_time_local asc")
-
     def getRecordListByCondition(self, condition):
         logging.debug('>>')
         if condition is None:

--- a/pytrainer/save.py
+++ b/pytrainer/save.py
@@ -1,59 +1,81 @@
 # -*- coding: utf-8 -*-
 
-#Copyright (C) Fiz Vazquez vud1@sindominio.net
+# Copyright (C) Fiz Vazquez vud1@sindominio.net
+# Copyright (C) Arto Jantunen <viiru@iki.fi>
 
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; either version 2
-#of the License, or (at your option) any later version.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
 
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-from .lib.fileUtils import fileUtils
+import csv
 from pytrainer.gui.dialogs import save_file_chooser_dialog
-import logging
-import traceback
+from pytrainer.core.activity import Activity
 
-class Save:
-    def __init__(self, data_path = None, record = None):
-        self.record = record
-        self.data_path = data_path
+
+class Save(object):
+    CSV_HEADER = (
+        "date_time_local",
+        "title",
+        "sports.name",
+        "distance",
+        "duration",
+        "average",
+        "maxspeed",
+        "pace",
+        "maxpace",
+        "beats",
+        "maxbeats",
+        "calories",
+        "upositive",
+        "unegative",
+        "comments",
+    )
+
+    def __init__(self, ddbb):
+        self.ddbb = ddbb
+
+    @staticmethod
+    def _convert_activity(activity):
+        for value in (
+                activity.date_time_local,
+                activity.title,
+                activity.sport.name,
+                activity.distance,
+                activity.duration,
+                activity.average,
+                activity.maxspeed,
+                activity.pace,
+                activity.maxpace,
+                activity.beats,
+                activity.maxbeats,
+                activity.calories,
+                activity.upositive,
+                activity.unegative,
+                activity.comments,
+        ):
+            if isinstance(value, float):
+                yield round(value, 2)
+            else:
+                yield value
+
+    def _read_activities(self):
+        for activity in self.ddbb.session.query(Activity).order_by(Activity.date_time_utc):
+            yield self._convert_activity(activity)
 
     def run(self):
-        logging.debug('>>')
         filename = save_file_chooser_dialog(title="savecsvfile", pattern="*.csv")
-        records = self.record.getAllrecord()
-        # CSV Header
-        content = "date_time_local,title,sports.name,distance,duration,average,maxspeed,pace,maxpace,beats,maxbeats,calories,upositive,unegative,comments\n"
-        try:
-            for record in records:
-                line = ""
-                for i, data in enumerate(record):
-                    if i in [3, 5, 6, 7, 8, 12, 13]:
-                        try:
-                            data = round(data, 2)
-                        except:
-                            pass             
-                    data = "%s" %data
-                    data = data.replace(",", " ")  
-                    data = data.replace("\n", " ")             
-                    data = data.replace("\r", " ")          
-                    if i>0: 
-                        line += ",%s" %data
-                    else:
-                        line += "%s" %data      
-                content += "%s\n" %line
-            logging.info("Record data successfully retrieved. Choosing file to save it")
-            file = fileUtils(filename,content)
-            file.run()
-        except:
-            logging.debug("Traceback: %s" % traceback.format_exc())
-        logging.debug('<<')
-
+        with open(filename, 'w', encoding='utf-8') as csv_file:
+            writer = csv.writer(csv_file, lineterminator="\n")
+            # CSV Header
+            writer.writerow(self.CSV_HEADER)
+            writer.writerows(self._read_activities())

--- a/pytrainer/test/core/test_activity.py
+++ b/pytrainer/test/core/test_activity.py
@@ -42,33 +42,35 @@ class ActivityTest(unittest.TestCase):
         self.uc.set_us(False)
         self.service = ActivityService(pytrainer_main=main)
         records_table = DeclarativeBase.metadata.tables['records']
-        self.ddbb.session.execute(records_table.insert({'distance': 46.18,
-                                                            'maxspeed': 44.6695617695,
-                                                            'maxpace': 1.2,
-                                                            'title': u'test activity',
-                                                            'unegative': 564.08076273,
-                                                            'upositive': 553.05993673,
-                                                            'average': 22.3882142185,
-                                                            'date_time_local': u'2016-07-24 12:58:23+0300',
-                                                            'calories': 1462,
-                                                            'beats': 115.0,
-                                                            'comments': u'test comment',
-                                                            'pace': 2.4,
-                                                            'date_time_utc': u'2016-07-24T09:58:23Z',
-                                                            'date': datetime.date(2016, 7, 24),
-                                                            'duration': 7426,
-                                                            'sport': 1,
-                                                            'maxbeats': 120.0}))
+        self.ddbb.session.execute(records_table.insert(), {
+            'distance': 46.18,
+            'maxspeed': 44.6695617695,
+            'maxpace': 1.2,
+            'title': 'test activity',
+            'unegative': 564.08076273,
+            'upositive': 553.05993673,
+            'average': 22.3882142185,
+            'date_time_local': '2016-07-24 12:58:23+0300',
+            'calories': 1462,
+            'beats': 115.0,
+            'comments': 'test comment',
+            'pace': 2.4,
+            'date_time_utc': '2016-07-24T09:58:23Z',
+            'date': datetime.date(2016, 7, 24),
+            'duration': 7426,
+            'sport': 1,
+            'maxbeats': 120.0})
         laps_table = DeclarativeBase.metadata.tables['laps']
-        self.ddbb.session.execute(laps_table.insert({'distance': 46181.9,
-                                                     'lap_number': 0,
-                                                     'calories': 1462,
-                                                         'elapsed_time': u'7426.0',
-                                                         'record': 1,
-                                                         'intensity': u'active',
-                                                         'avg_hr': 136,
-                                                         'max_hr': 173,
-                                                         'laptrigger': u'manual'}))
+        self.ddbb.session.execute(laps_table.insert(), {
+            'distance': 46181.9,
+            'lap_number': 0,
+            'calories': 1462,
+            'elapsed_time': '7426.0',
+            'record': 1,
+            'intensity': 'active',
+            'avg_hr': 136,
+            'max_hr': 173,
+            'laptrigger': 'manual'})
         self.activity = self.service.get_activity(1)
 
     def tearDown(self):

--- a/pytrainer/test/core/test_equipment.py
+++ b/pytrainer/test/core/test_equipment.py
@@ -365,8 +365,18 @@ class EquipmentServiceTest(unittest.TestCase):
                                                 "notes": u"Test notes.",
                                            "description": u"test item",
                                            "prior_usage": 0, "active": True})
-        self.mock_ddbb.session.execute("insert into records (distance,sport) values (250,1)")
-        self.mock_ddbb.session.execute("insert into record_equipment (record_id,equipment_id) values (1,1)")
+        record_table = DeclarativeBase.metadata.tables['records']
+        record_to_equipment = DeclarativeBase.metadata.tables['record_equipment']
+        self.mock_ddbb.session.execute(record_table.insert(),
+                                       {
+                                           "sport": 1,
+                                           "distance": 250,
+                                       })
+        self.mock_ddbb.session.execute(record_to_equipment.insert(),
+                                       {
+                                           "record_id": 1,
+                                           "equipment_id": 1,
+                                       })
         equipment = self.equipment_service.get_equipment_item(1)
         usage = self.equipment_service.get_equipment_usage(equipment)
         self.assertEqual(250, usage)

--- a/pytrainer/waypoint.py
+++ b/pytrainer/waypoint.py
@@ -18,8 +18,9 @@
 
 import logging
 from pytrainer.lib.date import unixtime2date
-from sqlalchemy import Column, Unicode, Float, Integer, Date
+from sqlalchemy import Column, Unicode, Float, Integer, Date, select
 from pytrainer.lib.ddbb import DeclarativeBase
+
 
 class Waypoint(DeclarativeBase):
     __tablename__ = 'waypoints'
@@ -69,19 +70,30 @@ class WaypointService(object):
         logging.debug("<<")
         return waypoint.id
 
-    def getwaypointInfo(self,id_waypoint):
-        logging.debug(">>")
-        retorno = self.pytrainer_main.ddbb.select("waypoints",
-                                "lat,lon,ele,comment,time,name,sym",
-                                "id_waypoint=%s" %id_waypoint)
-        logging.debug("<<")
-        return retorno
+    def getwaypointInfo(self, id_waypoint):
+        return self.pytrainer_main.ddbb.session.execute(
+            select(
+                Waypoint.lat,
+                Waypoint.lon,
+                Waypoint.ele,
+                Waypoint.comment,
+                Waypoint.time,
+                Waypoint.name,
+                Waypoint.sym,
+            ).where(Waypoint.id == id_waypoint)).all()
 
     def getAllWaypoints(self):
-        logging.debug(">>")
-        retorno = self.pytrainer_main.ddbb.select("waypoints","id_waypoint,lat,lon,ele,comment,time,name,sym","1=1 order by name")
-        logging.debug("<<")
-        return retorno
+        return self.pytrainer_main.ddbb.session.execute(
+            select(
+                Waypoint.id,
+                Waypoint.lat,
+                Waypoint.lon,
+                Waypoint.ele,
+                Waypoint.comment,
+                Waypoint.time,
+                Waypoint.name,
+                Waypoint.sym,
+            ).order_by(Waypoint.name)).all()
 
     def actualize_fromgpx(self,gpxfile):
         logging.debug(">>")

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup( 	name = "pytrainer",
 		('share/applications/',['pytrainer.desktop'])
 		],
 	scripts=['bin/pytrainer'],
-	install_requires=['SQLAlchemy<2.0',
+	install_requires=['SQLAlchemy',
 			'python-dateutil',
 			'matplotlib',
 			'lxml'],


### PR DESCRIPTION
* Remove unused waypoint code from googlemaps extension
* Modernize Activity joinedload syntax
* Modernize ActivityTest table insert syntax
* Use SQLAlchemy table.insert() in EquipmentServiceTest
* Convert WaypointService to use sqlalchemy.select instead of ddbb.select
* Remove commented-out ddbb.select call from the googleearth plugin
* Convert Save to CSVWriter and Activity
* Remove ddbb.select()
* Remove version restriction from the SQLAlchemy dependency
