### PR TITLE
Sqlalchemy 2.0 API Update

### DIFF
--- a/pytrainer/core/activity.py
+++ b/pytrainer/core/activity.py
@@ -62,6 +62,33 @@ class Lap(DeclarativeBase):
     start_lat = Column(Float)
     start_lon = Column(Float)
 
+    def __eq__(self, other):
+        if not isinstance(other, Lap):
+            return NotImplemented
+        return (self.avg_hr == other.avg_hr and
+                self.calories == other.calories and
+                self.comments == other.comments and
+                self.distance == other.distance and
+                self.elapsed_time == other.elapsed_time and
+                self.end_lat == other.end_lat and
+                self.end_lon == other.end_lon and
+                self.id_lap == other.id_lap and
+                self.intensity == other.intensity and
+                self.lap_number == other.lap_number and
+                self.laptrigger == other.laptrigger and
+                self.max_hr == other.max_hr and
+                self.max_speed == other.max_speed and
+                self.record == other.record and
+                self.start_lat == other.start_lat and
+                self.start_lon == other.start_lon)
+
+    def __repr__(self):
+        return (f"Lap(avg_hr={self.avg_hr}, calories={self.calories}, comments={self.comments!r}, "
+                f"distance={self.distance}, elapsed_time={self.elapsed_time!r}, end_lat={self.end_lat}, "
+                f"end_lon={self.end_lon}, id_lap={self.id_lap}, intensity={self.intensity!r}, "
+                f"lap_number={self.lap_number}, laptrigger={self.laptrigger}, max_hr={self.max_hr}, "
+                f"max_speed={self.max_speed}, record={self.record}, start_lat={self.start_lat}, start_lon={self.start_lon})")
+
     @property
     def duration(self):
         return float(self.elapsed_time)
@@ -277,6 +304,39 @@ class Activity(DeclarativeBase):
     def __init__(self, **kwargs):
         self._initialize()
         super(Activity, self).__init__(**kwargs)
+
+    def __eq__(self, other):
+        if not isinstance(other, Activity):
+            return False
+        return (
+            self.average == other.average and
+            self.beats == other.beats and
+            self.calories == other.calories and
+            self.comments == other.comments and
+            self.date == other.date and
+            self.date_time_local == other.date_time_local and
+            self.date_time_utc == other.date_time_utc and
+            self.distance == other.distance and
+            self.duration == other.duration and
+            self.id == other.id and
+            self.maxbeats == other.maxbeats and
+            self.maxpace == other.maxpace and
+            self.maxspeed == other.maxspeed and
+            self.pace == other.pace and
+            self.sport_id == other.sport_id and
+            self.title == other.title and
+            self.unegative == other.unegative and
+            self.upositive == other.upositive
+        )
+
+    def __repr__(self):
+        return (
+            f"<Activity(id={self.id}, title={self.title}, date={self.date}, duration={self.duration}, "
+            f"distance={self.distance}, average={self.average}, upositive={self.upositive}, "
+            f"unegative={self.unegative}, maxspeed={self.maxspeed}, maxpace={self.maxpace}, "
+            f"pace={self.pace}, beats={self.beats}, maxbeats={self.maxbeats}, calories={self.calories}, "
+            f"date_time_local={self.date_time_local}, date_time_utc={self.date_time_utc}, sport_id={self.sport_id})>"
+        )
 
     @reconstructor
     def _initialize(self):

--- a/pytrainer/core/sport.py
+++ b/pytrainer/core/sport.py
@@ -61,9 +61,12 @@ class Sport(DeclarativeBase):
                 self.met == other.met and self.name == other.name and
                 self.weight == other.weight)   # skipped color (an object)
 
-    def __str__(self):
+    def __repr__(self):
         return (f"Sport(id={self.id}, name={self.name}, color={self.color}, "
                 f"max_pace={self.max_pace}, met={self.met}, weight={self.weight})")
+
+    def __hash__(self):
+        return id( self )
 
 class SportServiceException(Exception):
 

--- a/pytrainer/core/sport.py
+++ b/pytrainer/core/sport.py
@@ -54,6 +54,17 @@ class Sport(DeclarativeBase):
         self.color = Color(0x0000ff)
         super(Sport, self).__init__(**kwargs)
 
+    def __eq__(self, other):
+        if not isinstance(other, Sport):
+            return NotImplemented
+        return (self.id == other.id and self.max_pace == other.max_pace and
+                self.met == other.met and self.name == other.name and
+                self.weight == other.weight)   # skipped color (an object)
+
+    def __str__(self):
+        return (f"Sport(id={self.id}, name={self.name}, color={self.color}, "
+                f"max_pace={self.max_pace}, met={self.met}, weight={self.weight})")
+
 class SportServiceException(Exception):
 
     def __init__(self, value):

--- a/pytrainer/lib/listview.py
+++ b/pytrainer/lib/listview.py
@@ -29,7 +29,7 @@ class ListSearch(object):
         self.past = 0
         self.duration = 0
         self.distance = 0        
-        self.listSport = sport_service.get_all_sports()
+        self.sport_service = sport_service
         
         self.listPast = [[_('All Time'), -99999], [_('Last 4 Weeks'), -31],
                          [_('Last 6 Months'), -183], [_('Last 12 Months'), -366]]
@@ -70,7 +70,8 @@ class ListSearch(object):
         if self.title:
             _andlist.append(Activity.title.like('%' + self.title + '%'))
         if self.sport:
-            _andlist.append(Activity.sport == self.listSport[self.sport-1])
+            listSport = self.sport_service.get_all_sports()
+            _andlist.append(Activity.sport == listSport[self.sport-1])
         if self.listPast[self.past][1]:
             _delta = datetime.timedelta(days=self.listPast[self.past][1])
             _date = datetime.datetime.today() + _delta
@@ -115,8 +116,8 @@ class ListSearch(object):
         liststore_lsa.clear() #Delete all items
         #Re-add "All Sports"
         liststore_lsa.append([firstEntry])
-        #Re-add all sports in listSport
-        for sport in self.listSport:
+        #Re-add all sports
+        for sport in self.sport_service.get_all_sports():
             liststore_lsa.append([sport.name])
         self.parent.lsa_sport.set_active(0)
         #Add handler manually, so above changes do not trigger recursive loop

--- a/pytrainer/test/core/test_activity.py
+++ b/pytrainer/test/core/test_activity.py
@@ -68,7 +68,6 @@ class ActivityTest(unittest.TestCase):
             'avg_hr': 136,
             'max_hr': 173,
             'laptrigger': 'manual'})
-        self.activity = self.service.get_activity(1)
 
     def tearDown(self):
         self.service.clear_pool()
@@ -76,33 +75,49 @@ class ActivityTest(unittest.TestCase):
         self.ddbb.drop_tables()
         self.uc.set_us(False)
 
+    def test_activities_get_activity(self):
+        activity = self.service.get_activity(1)
+        self.assertEqual(activity.distance, 46.18)
+        self.assertEqual(activity.duration, 7426)
+        self.assertEqual(activity.sport_name, 'Mountain Bike')
+        # TODO: can add more
+
     def test_activity_date_time(self):
-        self.assertEqual(self.activity.date_time, datetime.datetime(2016, 7, 24,
-                                                                        12, 58, 23,
-                                                    tzinfo=tzoffset(None, 10800)))
+        activity = self.service.get_activity(1)
+        self.assertEqual( activity.date_time,
+                          datetime.datetime(2016, 7, 24, 12, 58, 23, tzinfo=tzoffset(None, 10800)
+                          )
+                        )
 
     def test_activity_distance(self):
-        self.assertEqual(self.activity.distance, 46.18)
+        activity = self.service.get_activity(1)
+        self.assertEqual(activity.distance, 46.18)
 
     def test_activity_sport_name(self):
-        self.assertEqual(self.activity.sport_name, 'Mountain Bike')
+        activity = self.service.get_activity(1)
+        self.assertEqual(activity.sport_name, 'Mountain Bike')
 
     def test_activity_duration(self):
-        self.assertEqual(self.activity.duration, 7426)
+        activity = self.service.get_activity(1)
+        self.assertEqual(activity.duration, 7426)
 
     def test_activity_time(self):
-        self.assertEqual(self.activity.time, self.activity.duration)
+        activity = self.service.get_activity(1)
+        self.assertEqual(activity.time, activity.duration)
 
     def test_activity_starttime(self):
-        self.assertEqual(self.activity.starttime, '12:58:23')
+        activity = self.service.get_activity(1)
+        self.assertEqual(activity.starttime, '12:58:23')
 
     def test_activity_time_tuple(self):
-        self.assertEqual(self.activity.time_tuple, (2, 3, 46))
+        activity = self.service.get_activity(1)
+        self.assertEqual(activity.time_tuple, (2, 3, 46))
 
     def test_activity_lap(self):
+        activity = self.service.get_activity(1)
         self.maxDiff = None
         self.assertEqual(
-            self.activity.laps[0],
+            activity.laps[0],
             {
                 'distance': 46181.9,
                 'end_lon': None,
@@ -121,46 +136,49 @@ class ActivityTest(unittest.TestCase):
                 'start_lat': None,
                 'max_speed': None},
         )
-        lap = self.activity.Laps[0]
+        lap = activity.Laps[0]
         self.assertEqual(lap.distance, 46181.9)
         self.assertEqual(lap.duration, 7426.0)
         self.assertEqual(lap.calories, 1462)
         self.assertEqual(lap.avg_hr, 136)
         self.assertEqual(lap.max_hr, 173)
-        self.assertEqual(lap.activity, self.activity)
+        self.assertEqual(lap.activity, activity)
         self.assertEqual(lap.lap_number, 0)
         self.assertEqual(lap.intensity, u'active')
         self.assertEqual(lap.laptrigger, Laptrigger.MANUAL)
 
     def test_activity_get_value_f(self):
-        self.assertEqual(self.activity.get_value_f('distance', "%0.2f"), '46.18')
-        self.assertEqual(self.activity.get_value_f('average', "%0.2f"), '22.39')
-        self.assertEqual(self.activity.get_value_f('maxspeed', "%0.2f"), '44.67')
-        self.assertEqual(self.activity.get_value_f('time', '%s'), '2:03:46')
-        self.assertEqual(self.activity.get_value_f('calories', "%0.0f"), '1462')
-        self.assertEqual(self.activity.get_value_f('pace', "%s"), '2:40')
-        self.assertEqual(self.activity.get_value_f('maxpace', "%s"), '1:20')
-        self.assertEqual(self.activity.get_value_f('upositive', "%0.2f"), '553.06')
-        self.assertEqual(self.activity.get_value_f('unegative', "%0.2f"), '564.08')
+        activity = self.service.get_activity(1)
+        self.assertEqual(activity.get_value_f('distance', "%0.2f"), '46.18')
+        self.assertEqual(activity.get_value_f('average', "%0.2f"), '22.39')
+        self.assertEqual(activity.get_value_f('maxspeed', "%0.2f"), '44.67')
+        self.assertEqual(activity.get_value_f('time', '%s'), '2:03:46')
+        self.assertEqual(activity.get_value_f('calories', "%0.0f"), '1462')
+        self.assertEqual(activity.get_value_f('pace', "%s"), '2:40')
+        self.assertEqual(activity.get_value_f('maxpace', "%s"), '1:20')
+        self.assertEqual(activity.get_value_f('upositive', "%0.2f"), '553.06')
+        self.assertEqual(activity.get_value_f('unegative', "%0.2f"), '564.08')
 
     def test_activity_get_value_f_us(self):
+        activity = self.service.get_activity(1)
         self.uc.set_us(True)
-        self.assertEqual(self.activity.get_value_f('distance', "%0.2f"), '28.69')
-        self.assertEqual(self.activity.get_value_f('average', "%0.2f"), '13.91')
-        self.assertEqual(self.activity.get_value_f('maxspeed', "%0.2f"), '27.76')
-        self.assertEqual(self.activity.get_value_f('time', '%s'), '2:03:46')
-        self.assertEqual(self.activity.get_value_f('calories', "%0.0f"), '1462')
-        self.assertEqual(self.activity.get_value_f('pace', "%s"), '4:17')
-        self.assertEqual(self.activity.get_value_f('maxpace', "%s"), '2:09')
-        self.assertEqual(self.activity.get_value_f('upositive', "%0.2f"), '1814.50')
-        self.assertEqual(self.activity.get_value_f('unegative', "%0.2f"), '1850.66')
+        self.assertEqual(activity.get_value_f('distance', "%0.2f"), '28.69')
+        self.assertEqual(activity.get_value_f('average', "%0.2f"), '13.91')
+        self.assertEqual(activity.get_value_f('maxspeed', "%0.2f"), '27.76')
+        self.assertEqual(activity.get_value_f('time', '%s'), '2:03:46')
+        self.assertEqual(activity.get_value_f('calories', "%0.0f"), '1462')
+        self.assertEqual(activity.get_value_f('pace', "%s"), '4:17')
+        self.assertEqual(activity.get_value_f('maxpace', "%s"), '2:09')
+        self.assertEqual(activity.get_value_f('upositive', "%0.2f"), '1814.50')
+        self.assertEqual(activity.get_value_f('unegative', "%0.2f"), '1850.66')
 
     def test_activity_service_null(self):
         none_activity = self.service.get_activity(None)
         self.assertIsNone(none_activity.id)
 
     def test_activity_remove(self):
-        self.service.remove_activity_from_db(self.activity)
+        activity = self.service.get_activity(1)
+        self.service.remove_activity_from_db(activity)
         try:
             self.service.get_activity(1)
         except NoResultFound:
@@ -169,13 +187,16 @@ class ActivityTest(unittest.TestCase):
             self.fail()
 
     def test_activities_for_day(self):
-        activity = list(self.service.get_activities_for_day(datetime.date(2016, 7, 24)))[0]
-        self.assertEqual(self.activity, activity)
+        activity = self.service.get_activity(1)
+        activity_for_day = list(self.service.get_activities_for_day(datetime.date(2016, 7, 24)))[0]
+        self.assertEqual(activity, activity_for_day)
 
     def test_activities_period(self):
-        activity = list(self.service.get_activities_period(DateRange.for_week_containing(datetime.date(2016, 7, 24))))[0]
-        self.assertEqual(self.activity, activity)
+        activity = self.service.get_activity(1)
+        activity_period = list(self.service.get_activities_period(DateRange.for_week_containing(datetime.date(2016, 7, 24))))[0]
+        self.assertEqual(activity, activity_period)
 
     def test_all_activities(self):
-        activity = list(self.service.get_all_activities())[0]
-        self.assertEqual(self.activity, activity)
+        activity = self.service.get_activity(1)
+        activities = list(self.service.get_all_activities())[0]
+        self.assertEqual(activity, activities)

--- a/pytrainer/test/core/test_activity.py
+++ b/pytrainer/test/core/test_activity.py
@@ -84,6 +84,8 @@ class ActivityTest(unittest.TestCase):
         activity1 = self.service.get_activity(1)
         activity2 = self.service.get_activity(1)
 
+        self.assertEqual(activity1, activity2)
+
         self.assertEqual(activity1.distance, 46.18)
         self.assertEqual(activity1.duration, 7426)
         self.assertEqual(activity1.sport.name, 'Mountain Bike')
@@ -129,6 +131,9 @@ class ActivityTest(unittest.TestCase):
 
     def test_activity_lap(self):
         activity = self.service.get_activity(1)
+        self.ddbb.session.add(activity)     # merge back into the session to avoid Detached error
+        self.ddbb.session.refresh(activity)
+
         self.maxDiff = None
         # we test our own deprecated accessor, we also test each attribute below
         warnings.filterwarnings('ignore', category=DeprecationWarning)
@@ -160,6 +165,7 @@ class ActivityTest(unittest.TestCase):
         self.assertEqual(lap.calories, 1462)
         self.assertEqual(lap.avg_hr, 136)
         self.assertEqual(lap.max_hr, 173)
+        self.assertEqual(lap.activity, activity)
         self.assertEqual(lap.lap_number, 0)
         self.assertEqual(lap.intensity, u'active')
         self.assertEqual(lap.laptrigger, Laptrigger.MANUAL)
@@ -217,7 +223,9 @@ class ActivityTest(unittest.TestCase):
         activity = self.service.get_activity(1)
         activities_for_day = self.service.get_activities_for_day(datetime.date(2016, 7, 24))
 
+
         activity1 = list(activities_for_day)[0]
+        self.assertEqual(activity, activity1)
 
         self.assertEqual(activity1.distance, 46.18)
         self.assertEqual(activity1.duration, 7426)
@@ -228,6 +236,7 @@ class ActivityTest(unittest.TestCase):
         activities_period = self.service.get_activities_period(DateRange.for_week_containing(datetime.date(2016, 7, 24)))
 
         activity1 = list(activities_period)[0]
+        self.assertEqual(activity, activity1)
 
         self.assertEqual(activity1.distance, 46.18)
         self.assertEqual(activity1.duration, 7426)
@@ -237,7 +246,9 @@ class ActivityTest(unittest.TestCase):
         activity = self.service.get_activity(1)
         all_activities = self.service.get_all_activities()
 
+
         activity1 = list(all_activities)[0]
+        self.assertEqual(activity, activity1)
 
         self.assertEqual(activity1.distance, 46.18)
         self.assertEqual(activity1.duration, 7426)

--- a/pytrainer/test/core/test_activity.py
+++ b/pytrainer/test/core/test_activity.py
@@ -69,6 +69,8 @@ class ActivityTest(unittest.TestCase):
             'max_hr': 173,
             'laptrigger': 'manual'})
 
+        self.ddbb.session.commit()
+
     def tearDown(self):
         self.service.clear_pool()
         self.ddbb.disconnect()

--- a/pytrainer/test/core/test_equipment.py
+++ b/pytrainer/test/core/test_equipment.py
@@ -293,6 +293,7 @@ class EquipmentServiceTest(unittest.TestCase):
         equipment.description = u"test description"
         stored_equipment = self.equipment_service.store_equipment(equipment)
         self.assertEqual(1, stored_equipment.id)
+        self.assertEqual(equipment.description, stored_equipment.description)
         
     def test_store_equipment_duplicate_description(self):
         self.mock_ddbb.session.execute(self.equipment_table.insert(),
@@ -314,11 +315,14 @@ class EquipmentServiceTest(unittest.TestCase):
                                                 "notes": u"Test notes.",
                                            "description": u"old description",
                                            "prior_usage": 200, "active": True})
+        self.mock_ddbb.session.commit()
+
         equipment = self.equipment_service.get_equipment_item(1)
         equipment.description = u"new description"
         self.equipment_service.store_equipment(equipment)
-        equipment = self.equipment_service.get_equipment_item(1)
-        self.assertEqual("new description", equipment.description)
+
+        stored_equipment = self.equipment_service.get_equipment_item(1)
+        self.assertEqual(equipment.description, stored_equipment.description)
         
     def test_update_equipment_duplicate_description(self):
         self.mock_ddbb.session.execute(self.equipment_table.insert(),
@@ -341,6 +345,8 @@ class EquipmentServiceTest(unittest.TestCase):
                                                 "notes": u"Test notes.",
                                            "description": u"test item",
                                            "prior_usage": 0, "active": True})
+        self.mock_ddbb.session.commit()
+
         record_table = DeclarativeBase.metadata.tables['records']
         record_to_equipment = DeclarativeBase.metadata.tables['record_equipment']
         self.mock_ddbb.session.execute(record_table.insert(),
@@ -353,6 +359,8 @@ class EquipmentServiceTest(unittest.TestCase):
                                            "record_id": 1,
                                            "equipment_id": 1,
                                        })
+        self.mock_ddbb.session.commit()
+
         equipment = self.equipment_service.get_equipment_item(1)
         usage = self.equipment_service.get_equipment_usage(equipment)
         self.assertEqual(250, usage)

--- a/pytrainer/test/core/test_sport.py
+++ b/pytrainer/test/core/test_sport.py
@@ -20,6 +20,7 @@ import unittest
 from pytrainer.core.sport import Sport, SportService, SportServiceException
 from pytrainer.lib.ddbb import DDBB
 from sqlalchemy.exc import IntegrityError, StatementError, OperationalError, InterfaceError, DataError
+from sqlalchemy import select
 
 class SportTest(unittest.TestCase):
 
@@ -46,7 +47,10 @@ class SportTest(unittest.TestCase):
         sport.id = "1"
         self.ddbb.session.add(sport)
         self.ddbb.session.commit()
-        sport = self.ddbb.session.query(Sport).filter(Sport.id == 1).one()
+        with self.ddbb.session as session:
+            stmt = select(Sport).where(Sport.id == 1)
+            result = session.execute(stmt)
+            sport = result.scalars().one()
         self.assertEqual(1, sport.id)
 
     def test_id_should_not_accept_non_integer_string(self):
@@ -89,7 +93,10 @@ class SportTest(unittest.TestCase):
         sport.met = "22.5"
         self.ddbb.session.add(sport)
         self.ddbb.session.commit()
-        sport = self.ddbb.session.query(Sport).filter(Sport.id == 1).one()
+        with self.ddbb.session as session:
+            stmt = select(Sport).where(Sport.id == 1)
+            result = session.execute(stmt)
+            sport = result.scalars().one()
         self.assertEqual(22.5, sport.met)
 
     def test_met_should_not_accept_non_float_string(self):
@@ -182,7 +189,10 @@ class SportTest(unittest.TestCase):
         sport.max_pace = 220.6
         self.ddbb.session.add(sport)
         self.ddbb.session.commit()
-        sport = self.ddbb.session.query(Sport).filter(Sport.id == 1).one()
+        with self.ddbb.session as session:
+            stmt = select(Sport).where(Sport.id == 1)
+            result = session.execute(stmt)
+            sport = result.scalars().one()
         self.assertEqual(220, sport.max_pace)
 
     def test_max_pace_should_not_accept_negative_value(self):

--- a/pytrainer/test/lib/test_listview.py
+++ b/pytrainer/test/lib/test_listview.py
@@ -63,9 +63,13 @@ class ListviewTest(unittest.TestCase):
         self.main.ddbb.session.add(Activity(sport=non_linear_sport,
                                             date=datetime.datetime(2018, 5, 6, 10, 0, 0),
                                             duration=1000, distance=25))
+        self.main.ddbb.session.commit()
+
         self.main.ddbb.session.add(Activity(sport=non_linear_sport,
                                             date=datetime.datetime(2018, 1, 6, 10, 0, 0),
                                             duration=10000, distance=150))
+        self.main.ddbb.session.commit()
+
         self.main.ddbb.session.add(Activity(sport=self.sport_service.get_sport(2),
                                             date=datetime.datetime(2018, 1, 6, 10, 0, 0),
                                             duration=10000, distance=100))

--- a/pytrainer/test/lib/test_listview.py
+++ b/pytrainer/test/lib/test_listview.py
@@ -90,15 +90,12 @@ class ListviewTest(unittest.TestCase):
     def test_listsearch_sport(self):
         self.parent.lsa_sport.set_active(3)
         active = self.parent.lsa_sport.get_active_text()
+        cond = self.parent.listsearch.condition
 
-        # eagerly load the sport relationship
-        stmt = select(Activity).options(joinedload(Activity.sport)).where(self.parent.listsearch.condition)
-        with self.main.ddbb.session as session:
-            result = session.execute(stmt)
-            by_sport = result.scalars().all()
-
-        self.assertEqual(len(by_sport), 2)
-        self.assertEqual(by_sport[0].sport.name, active)
+        records = self.main.record.getRecordListByCondition( cond )
+        self.assertEqual( len(records), 2)
+        for record in records:
+            self.assertEqual(record.sport.name, active)
 
     def test_listsearch_distance(self):
         self.parent.lsa_distance.set_active(4)

--- a/pytrainer/test/test_record.py
+++ b/pytrainer/test/test_record.py
@@ -15,6 +15,7 @@
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 import unittest
+import warnings
 from unittest.mock import Mock
 from datetime import datetime, date
 from dateutil.tz import tzoffset
@@ -83,8 +84,12 @@ class RecordTest(unittest.TestCase):
         self.assertEqual(activity.sport.id,   self.record._sport_service.get_sport_by_name(u"Run").id)
         self.assertEqual(activity.sport.name, self.record._sport_service.get_sport_by_name(u"Run").name)
         self.assertEqual(activity.title, u'test 1')
+
+        warnings.filterwarnings('ignore', category=DeprecationWarning)
+        lap_dict = activity.laps[0]
+        warnings.resetwarnings
         self.assertEqual(
-            activity.laps[0],
+            lap_dict,
             {
                 'distance': 46181.9,
                 'end_lon': None,
@@ -121,8 +126,12 @@ list_options['date_time_local'], also test that code path"""
         self.assertEqual(activity.sport.id,   self.record._sport_service.get_sport_by_name(u"Run").id)
         self.assertEqual(activity.sport.name, self.record._sport_service.get_sport_by_name(u"Run").name)
         self.assertEqual(activity.title, u'test 1')
+
+        warnings.filterwarnings('ignore', category=DeprecationWarning)
+        lap_dict = activity.laps[0]
+        warnings.resetwarnings
         self.assertEqual(
-            activity.laps[0],
+            lap_dict,
             {
                 'distance': 46181.9,
                 'end_lon': None,
@@ -151,6 +160,7 @@ list_options['date_time_local'], also test that code path"""
         self.record.updateRecord(update_dict, newid)
         activity = self.main.activitypool.get_activity(newid)
         self.assertEqual(activity.title, u'test 2')
+        self.assertEqual(activity.sport,      self.record._sport_service.get_sport_by_name(u"Bike"))
         self.assertEqual(activity.sport.id,   self.record._sport_service.get_sport_by_name(u"Bike").id)
         self.assertEqual(activity.sport.name, self.record._sport_service.get_sport_by_name(u"Bike").name)
 

--- a/pytrainer/test/test_record.py
+++ b/pytrainer/test/test_record.py
@@ -80,7 +80,8 @@ class RecordTest(unittest.TestCase):
         self.assertEqual(activity.date_time, datetime(2016, 7, 24, 12, 58, 23,
                                                        tzinfo=tzoffset(None, 10800)))
         self.assertEqual(activity.date_time_utc, u'2016-07-24T09:58:23Z')
-        self.assertEqual(activity.sport, self.record._sport_service.get_sport_by_name(u"Run"))
+        self.assertEqual(activity.sport.id,   self.record._sport_service.get_sport_by_name(u"Run").id)
+        self.assertEqual(activity.sport.name, self.record._sport_service.get_sport_by_name(u"Run").name)
         self.assertEqual(activity.title, u'test 1')
         self.assertEqual(
             activity.laps[0],
@@ -117,7 +118,8 @@ list_options['date_time_local'], also test that code path"""
         self.assertEqual(activity.date_time, datetime(2016, 7, 24, 12, 58, 23,
                                                        tzinfo=tzoffset(None, 10800)))
         self.assertEqual(activity.date_time_utc, u'2016-07-24T09:58:23Z')
-        self.assertEqual(activity.sport, self.record._sport_service.get_sport_by_name(u"Run"))
+        self.assertEqual(activity.sport.id,   self.record._sport_service.get_sport_by_name(u"Run").id)
+        self.assertEqual(activity.sport.name, self.record._sport_service.get_sport_by_name(u"Run").name)
         self.assertEqual(activity.title, u'test 1')
         self.assertEqual(
             activity.laps[0],
@@ -149,7 +151,8 @@ list_options['date_time_local'], also test that code path"""
         self.record.updateRecord(update_dict, newid)
         activity = self.main.activitypool.get_activity(newid)
         self.assertEqual(activity.title, u'test 2')
-        self.assertEqual(activity.sport, self.record._sport_service.get_sport_by_name(u"Bike"))
+        self.assertEqual(activity.sport.id,   self.record._sport_service.get_sport_by_name(u"Bike").id)
+        self.assertEqual(activity.sport.name, self.record._sport_service.get_sport_by_name(u"Bike").name)
 
     def test_get_day_list(self):
         self.record.insertRecord(self.summary)


### PR DESCRIPTION
Update to the new sqlalchemy 2.0 API:
    - replaced calls to the legacy query() method with the select() then session.execute() construct
    - use 'with' blocks with the context managers provided by Session to ensure safe opening/closing of sessions
 