### PR TITLE
Enable passing version info to setuptools_scm via git-archive

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=v*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst


### PR DESCRIPTION
See the "Git archives" section at
https://setuptools-scm.readthedocs.io/en/latest/usage/ for the
documentation this is based on.